### PR TITLE
Add `log` crate, replace all `println!` in code with appropriate log level

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -631,9 +631,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "memchr"
@@ -968,6 +968,7 @@ dependencies = [
  "hex",
  "hmac",
  "itertools",
+ "log",
  "once_cell",
  "rand 0.9.1",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ chrono = "0.4.31"
 rand = "0.9.1"
 futures = "0.3.25"
 thiserror = "2.0.12"
+log = "0.4.27"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full", "test-util"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ pub mod general;
 pub mod client;
 pub mod market;
 pub mod trade;
-pub mod  position;
+pub mod position;
 pub mod asset;
 pub mod account;
 pub mod ws;

--- a/src/trade.rs
+++ b/src/trade.rs
@@ -1,3 +1,4 @@
+use log::error;
 use serde_json::{json, Value};
 
 use crate::api::{Trade, API};
@@ -392,7 +393,7 @@ impl Trader {
             }
             // If the category is invalid, print an error message
             _ => {
-                println!("Invalid category");
+                error!("Invalid category");
             }
         }
 
@@ -457,7 +458,7 @@ impl Trader {
             }
             _ => {
                 // Print an error message if the category is invalid
-                println!("Invalid category");
+                error!("Invalid category");
             }
         }
 
@@ -528,7 +529,7 @@ impl Trader {
                 parameters.insert("category".into(), req.category.as_str().into());
             }
             _ => {
-                println!("Invalid category");
+                error!("Invalid category");
             }
         }
         let mut requests_array: Vec<Value> = Vec::new();
@@ -612,7 +613,7 @@ impl Trader {
                         0 | 1 | 2 => {
                             parameters.insert("positionIdx".into(), v.to_string().into());
                         }
-                        _ => println!("Invalid position idx"),
+                        _ => error!("Invalid position idx"),
                     }
                 }
                 if let Some(order_link_id) = req.order_link_id {

--- a/src/ws.rs
+++ b/src/ws.rs
@@ -9,7 +9,7 @@ use crate::model::{
 use crate::trade::build_ws_orders;
 use crate::util::{build_json_request, generate_random_uid, get_timestamp};
 use futures::{SinkExt, StreamExt};
-use log::debug;
+use log::trace;
 use serde_json::{json, Value};
 use std::collections::BTreeMap;
 use std::time::Instant;
@@ -52,10 +52,10 @@ impl Stream {
                 let response: PongResponse = serde_json::from_str(&data)?;
                 match response {
                     PongResponse::PublicPong(pong) => {
-                        debug!("Pong received successfully: {:#?}", pong);
+                        trace!("Pong received successfully: {:#?}", pong);
                     }
                     PongResponse::PrivatePong(pong) => {
-                        debug!("Pong received successfully: {:#?}", pong);
+                        trace!("Pong received successfully: {:#?}", pong);
                     }
                 }
             }

--- a/src/ws.rs
+++ b/src/ws.rs
@@ -9,6 +9,7 @@ use crate::model::{
 use crate::trade::build_ws_orders;
 use crate::util::{build_json_request, generate_random_uid, get_timestamp};
 use futures::{SinkExt, StreamExt};
+use log::debug;
 use serde_json::{json, Value};
 use std::collections::BTreeMap;
 use std::time::Instant;
@@ -51,10 +52,10 @@ impl Stream {
                 let response: PongResponse = serde_json::from_str(&data)?;
                 match response {
                     PongResponse::PublicPong(pong) => {
-                        println!("Pong received successfully: {:#?}", pong);
+                        debug!("Pong received successfully: {:#?}", pong);
                     }
                     PongResponse::PrivatePong(pong) => {
-                        println!("Pong received successfully: {:#?}", pong);
+                        debug!("Pong received successfully: {:#?}", pong);
                     }
                 }
             }


### PR DESCRIPTION
I started using ping to keep alive, because I think you don't do it under the hood? And when I did I started seeing:
```
Pong received successfully: PongData {
    ret_code: None,
    success: Some(
        true,
    ),
    ret_msg: "",
    conn_id: "d00sbd1qo29qtukuqb1g-1s0ew",
    req_id: Some(
        "iV1uw",
    ),
    args: None,
    data: None,
    op: "auth",
}
```

which is quite verbose. So I changed from `println!` to `log`.

you can setup logging yourself e.g. using [`fern`[(https://crates.io/crates/fern) and [`colored`](https://crates.io/crates/colored) , like this:

```rust
use colored::Colorize;
use log::*;
use log;

// This should NOT be called in bybit-rs, it should be called by any program using bybit-rs
pub(crate) fn init_logging_with_level(log_level: log::LevelFilter) { 
    println!("Setting up logging with level: {log_level}");
    fern::Dispatch::new()
        .format(|out, message, record| {
            let time = Local::now().format("%H:%M:%S");
            let level = match record.level() {
                log::Level::Error => "ERROR".red(),
                log::Level::Warn => "WARN".yellow(),
                log::Level::Info => "INFO".green(),
                log::Level::Debug => "DEBUG".blue(),
                log::Level::Trace => "TRACE".white(),
            };
            out.finish(format_args!("{time} {level} > {message}"));
        })
        .level(log_level)
        .chain(std::io::stdout())
        .apply()
        .unwrap();

    println!(
        "ISN'T AN ERROR > ✅ Logging initialized with level: {log_level} (if you see this message once, logging is not properly setup)"
    );
    log::error!(
        "✅ Logging initialized with level: {log_level} (if you see this message once, logging is not properly setup)"
    );
}

```

This allows us, consumers of `bybit-rs` to control the log level, by using  RUST_LOG env, like so:
```
export RUST_LOG=my_crate_using_bybit_rs=debug,rs_bybit=off
```

this sets log level to `debug` for my crate, but turns logging of bybit-rs `off`.