### PR TITLE
Remove all `unwrap()` in source code, replace by a new error for sender.send

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -22,6 +22,9 @@ pub enum BybitError {
     #[error("Bybit error: {0}")]
     BybitError(BybitContentError),
 
+    #[error("Failed to emit value on channel, underlying: {underlying}")]
+    ChannelSendError { underlying: String },
+
     /// KlineValueMissingError variant that holds the index of the missing value, and the name of the missing value.
     /// This variant is used when a value in a kline vector is missing.
     #[error("Invalid Vec for Kline: {name} at {index} is missing")]

--- a/src/util.rs
+++ b/src/util.rs
@@ -8,7 +8,12 @@ use std::collections::BTreeMap;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 pub fn build_request<T: ToString>(parameters: &BTreeMap<String, T>) -> String {
-    let mut request = String::with_capacity(parameters.iter().map(|(k, v)| k.len() + v.to_string().len() + 1).sum());
+    let mut request = String::with_capacity(
+        parameters
+            .iter()
+            .map(|(k, v)| k.len() + v.to_string().len() + 1)
+            .sum(),
+    );
     for (key, value) in parameters {
         request.push_str(key);
         request.push('=');
@@ -43,8 +48,10 @@ pub fn get_timestamp() -> u64 {
 }
 
 pub fn date_to_milliseconds(date_str: &str) -> u64 {
-    let naive_date = NaiveDate::parse_from_str(date_str, "%d%m%y").unwrap();
-    let naive_date_time = naive_date.and_hms_opt(0, 0, 0).unwrap();
+    let naive_date = NaiveDate::parse_from_str(date_str, "%d%m%y").expect("Failed to parse date");
+    let naive_date_time = naive_date
+        .and_hms_opt(0, 0, 0)
+        .expect("Failed to create NaiveDateTime");
     let datetime_utc = Utc.from_utc_datetime(&naive_date_time);
     datetime_utc.timestamp_millis() as u64
 }

--- a/src/ws.rs
+++ b/src/ws.rs
@@ -45,7 +45,14 @@ impl Stream {
             .client
             .wss_connect(endpoint, Some(request), private, None)
             .await?;
-        let data = response.next().await.unwrap()?;
+        let Some(data) = response.next().await else {
+            return Err(BybitError::Base(
+                "Failed to receive ping response".to_string(),
+            ));
+        };
+
+        let data = data
+            .map_err(|e| BybitError::Base(format!("Failed to get ping response, error {}", e)))?;
         match data {
             WsMessage::Text(data) => {
                 let response: PongResponse = serde_json::from_str(&data)?;
@@ -187,7 +194,11 @@ impl Stream {
         let request = Subscription::new("subscribe", arr.iter().map(AsRef::as_ref).collect());
         self.ws_subscribe(request, category, move |event| {
             if let WebsocketEvents::OrderBookEvent(order_book) = event {
-                sender.send(order_book).unwrap();
+                sender
+                    .send(order_book)
+                    .map_err(|e| BybitError::ChannelSendError {
+                        underlying: e.to_string(),
+                    })?;
             }
             Ok(())
         })
@@ -222,7 +233,11 @@ impl Stream {
         let handler = move |event| {
             if let WebsocketEvents::TradeEvent(trades) = event {
                 for trade in trades.data {
-                    sender.send(trade).unwrap();
+                    sender
+                        .send(trade)
+                        .map_err(|e| BybitError::ChannelSendError {
+                            underlying: e.to_string(),
+                        })?;
                 }
             }
             Ok(())
@@ -259,17 +274,26 @@ impl Stream {
             .collect();
         let request = Subscription::new("subscribe", arr.iter().map(String::as_str).collect());
 
-        let handler = move |event| {
-            if let WebsocketEvents::TickerEvent(tickers) = event {
-                match tickers.data {
-                    Tickers::Linear(linear_ticker) => {
-                        sender.send(Tickers::Linear(linear_ticker)).unwrap()
+        let handler =
+            move |event| {
+                if let WebsocketEvents::TickerEvent(tickers) = event {
+                    match tickers.data {
+                        Tickers::Linear(linear_ticker) => {
+                            sender.send(Tickers::Linear(linear_ticker)).map_err(|e| {
+                                BybitError::ChannelSendError {
+                                    underlying: e.to_string(),
+                                }
+                            })?;
+                        }
+                        Tickers::Spot(spot_ticker) => sender
+                            .send(Tickers::Spot(spot_ticker))
+                            .map_err(|e| BybitError::ChannelSendError {
+                                underlying: e.to_string(),
+                            })?,
                     }
-                    Tickers::Spot(spot_ticker) => sender.send(Tickers::Spot(spot_ticker)).unwrap(),
                 }
-            }
-            Ok(())
-        };
+                Ok(())
+            };
 
         self.ws_subscribe(request, category, handler).await
     }
@@ -287,7 +311,11 @@ impl Stream {
 
         let handler = move |event| {
             if let WebsocketEvents::LiquidationEvent(liquidation) = event {
-                sender.send(liquidation.data).unwrap();
+                sender
+                    .send(liquidation.data)
+                    .map_err(|e| BybitError::ChannelSendError {
+                        underlying: e.to_string(),
+                    })?;
             }
             Ok(())
         };
@@ -307,7 +335,11 @@ impl Stream {
         let request = Subscription::new("subscribe", arr.iter().map(AsRef::as_ref).collect());
         self.ws_subscribe(request, category, move |event| {
             if let WebsocketEvents::KlineEvent(kline) = event {
-                sender.send(kline).unwrap();
+                sender
+                    .send(kline)
+                    .map_err(|e| BybitError::ChannelSendError {
+                        underlying: e.to_string(),
+                    })?;
             }
             Ok(())
         })
@@ -333,7 +365,9 @@ impl Stream {
         self.ws_priv_subscribe(request, move |event| {
             if let WebsocketEvents::PositionEvent(position) = event {
                 for v in position.data {
-                    sender.send(v).unwrap();
+                    sender.send(v).map_err(|e| BybitError::ChannelSendError {
+                        underlying: e.to_string(),
+                    })?;
                 }
             }
             Ok(())
@@ -361,7 +395,9 @@ impl Stream {
         self.ws_priv_subscribe(request, move |event| {
             if let WebsocketEvents::ExecutionEvent(execute) = event {
                 for v in execute.data {
-                    sender.send(v).unwrap();
+                    sender.send(v).map_err(|e| BybitError::ChannelSendError {
+                        underlying: e.to_string(),
+                    })?;
                 }
             }
             Ok(())
@@ -379,7 +415,9 @@ impl Stream {
         self.ws_priv_subscribe(request, move |event| {
             if let WebsocketEvents::FastExecEvent(execution) = event {
                 for v in execution.data {
-                    sender.send(v).unwrap();
+                    sender.send(v).map_err(|e| BybitError::ChannelSendError {
+                        underlying: e.to_string(),
+                    })?;
                 }
             }
             Ok(())
@@ -407,7 +445,9 @@ impl Stream {
         self.ws_priv_subscribe(request, move |event| {
             if let WebsocketEvents::OrderEvent(order) = event {
                 for v in order.data {
-                    sender.send(v).unwrap();
+                    sender.send(v).map_err(|e| BybitError::ChannelSendError {
+                        underlying: e.to_string(),
+                    })?;
                 }
             }
             Ok(())
@@ -424,7 +464,9 @@ impl Stream {
         self.ws_priv_subscribe(request, move |event| {
             if let WebsocketEvents::Wallet(wallet) = event {
                 for v in wallet.data {
-                    sender.send(v).unwrap();
+                    sender.send(v).map_err(|e| BybitError::ChannelSendError {
+                        underlying: e.to_string(),
+                    })?;
                 }
             }
             Ok(())


### PR DESCRIPTION
I got some crash in `sender.send` due to the unwrap, and I wanna propagate the error.

So this PR replaces ALL `unwrap` with a Result and Error when applicable, and some `expect` for time utils.