### PR TITLE
Fix position info

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -387,6 +387,14 @@ impl Client {
                 let response = response.json::<T>().await?;
                 Ok(response)
             }
+            StatusCode::OK => match response.json::<T>().await {
+                Ok(data) => Ok(data),
+                Err(e) => Err(BybitError::Base(format!(
+                    "Json decode error parsing response as {} {:?}",
+                    type_name::<T>(),
+                    e
+                ))),
+            },
             // If the status code is BAD_REQUEST, deserialize the response body into BybitContentError and
             // wrap it in BybitError and return it
             StatusCode::BAD_REQUEST => {

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,4 +1,4 @@
-
+use std::any::type_name;
 
 use tokio::net::TcpStream;
 
@@ -383,10 +383,6 @@ impl Client {
         // Match the status code of the response
         match response.status() {
             // If the status code is OK, deserialize the response body into T and return it
-            StatusCode::OK => {
-                let response = response.json::<T>().await?;
-                Ok(response)
-            }
             StatusCode::OK => match response.json::<T>().await {
                 Ok(data) => Ok(data),
                 Err(e) => Err(BybitError::Base(format!(

--- a/src/model.rs
+++ b/src/model.rs
@@ -2185,6 +2185,7 @@ impl<'a> PositionRequest<'a> {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct InfoResponse {
     pub ret_code: i32,
     pub ret_msg: String,

--- a/src/model.rs
+++ b/src/model.rs
@@ -2276,8 +2276,9 @@ pub struct PositionInfo {
     pub size: f64,
 
     #[serde(with = "string_to_float_optional")]
-    pub session_avg_price: Option<f64>,
+    pub avg_price: Option<f64>,
 
+    #[serde(with = "string_to_float")]
     pub position_value: f64,
 
     pub trade_mode: i32,
@@ -2332,6 +2333,53 @@ pub struct PositionInfo {
 
     pub created_time: String,
     pub updated_time: String,
+}
+#[cfg(test)]
+mod test_decode_position_info {
+    use super::*;
+
+    #[test]
+    fn test_deserialize() {
+        let json = r#"
+            {
+                "positionIdx": 0,
+                "riskId": 1,
+                "riskLimitValue": "150",
+                "symbol": "BTCUSD",
+                "side": "Sell",
+                "size": "300",
+                "avgPrice": "27464.50441675",
+                "positionValue": "0.01092319",
+                "tradeMode": 0,
+                "positionStatus": "Normal",
+                "autoAddMargin": 1,
+                "adlRankIndicator": 2,
+                "leverage": "10",
+                "positionBalance": "0.00139186",
+                "markPrice": "28224.50",
+                "liqPrice": "",
+                "bustPrice": "999999.00",
+                "positionMM": "0.0000015",
+                "positionIM": "0.00010923",
+                "tpslMode": "Full",
+                "takeProfit": "0.00",
+                "stopLoss": "0.00",
+                "trailingStop": "0.00",
+                "unrealisedPnl": "-0.00029413",
+                "curRealisedPnl": "0.00013123",
+                "cumRealisedPnl": "-0.00096902",
+                "seq": 5723621632,
+                "isReduceOnly": false,
+                "mmrSysUpdateTime": "",
+                "leverageSysUpdatedTime": "",
+                "sessionAvgPrice": "",
+                "createdTime": "1676538056258",
+                "updatedTime": "1697673600012"
+            }
+        "#;
+        let result = serde_json::from_str::<PositionInfo>(json);
+        assert_eq!(result.unwrap().avg_price, Some(27464.50441675));
+    }
 }
 
 #[derive(Clone, Default)]

--- a/src/model.rs
+++ b/src/model.rs
@@ -2278,8 +2278,8 @@ pub struct PositionInfo {
     #[serde(with = "string_to_float_optional")]
     pub avg_price: Option<f64>,
 
-    #[serde(with = "string_to_float")]
-    pub position_value: f64,
+    #[serde(with = "string_to_float_optional")]
+    pub position_value: Option<f64>,
 
     pub trade_mode: i32,
 
@@ -2317,8 +2317,8 @@ pub struct PositionInfo {
 
     pub trailing_stop: String,
 
-    #[serde(with = "string_to_float")]
-    pub unrealised_pnl: f64,
+    #[serde(with = "string_to_float_optional")]
+    pub unrealised_pnl: Option<f64>,
 
     #[serde(with = "string_to_float_optional")]
     pub cum_realised_pnl: Option<f64>,
@@ -2327,7 +2327,7 @@ pub struct PositionInfo {
 
     pub is_reduce_only: bool,
 
-    pub mmr_sys_update_time: String,
+    pub mmr_sys_updated_time: String,
 
     pub leverage_sys_updated_time: String,
 
@@ -2342,43 +2342,43 @@ mod test_decode_position_info {
     fn test_deserialize() {
         let json = r#"
             {
-                "positionIdx": 0,
-                "riskId": 1,
-                "riskLimitValue": "150",
-                "symbol": "BTCUSD",
-                "side": "Sell",
-                "size": "300",
-                "avgPrice": "27464.50441675",
-                "positionValue": "0.01092319",
-                "tradeMode": 0,
-                "positionStatus": "Normal",
-                "autoAddMargin": 1,
-                "adlRankIndicator": 2,
+                "symbol": "BTCUSDT",
                 "leverage": "10",
-                "positionBalance": "0.00139186",
-                "markPrice": "28224.50",
+                "autoAddMargin": 0,
+                "avgPrice": "0",
                 "liqPrice": "",
-                "bustPrice": "999999.00",
-                "positionMM": "0.0000015",
-                "positionIM": "0.00010923",
-                "tpslMode": "Full",
-                "takeProfit": "0.00",
-                "stopLoss": "0.00",
-                "trailingStop": "0.00",
-                "unrealisedPnl": "-0.00029413",
-                "curRealisedPnl": "0.00013123",
-                "cumRealisedPnl": "-0.00096902",
-                "seq": 5723621632,
+                "riskLimitValue": "2000000",
+                "takeProfit": "",
+                "positionValue": "",
                 "isReduceOnly": false,
-                "mmrSysUpdateTime": "",
+                "tpslMode": "Full",
+                "riskId": 1,
+                "trailingStop": "0",
+                "unrealisedPnl": "",
+                "markPrice": "102933.4",
+                "adlRankIndicator": 0,
+                "cumRealisedPnl": "-831.1052256",
+                "positionMM": "0",
+                "createdTime": "1747213635707",
+                "positionIdx": 0,
+                "positionIM": "0",
+                "seq": 9462192883,
+                "updatedTime": "1747231686827",
+                "side": "",
+                "bustPrice": "",
+                "positionBalance": "0",
                 "leverageSysUpdatedTime": "",
-                "sessionAvgPrice": "",
-                "createdTime": "1676538056258",
-                "updatedTime": "1697673600012"
+                "curRealisedPnl": "0",
+                "size": "0",
+                "positionStatus": "Normal",
+                "mmrSysUpdatedTime": "",
+                "stopLoss": "",
+                "tradeMode": 0,
+                "sessionAvgPrice": ""
             }
         "#;
         let result = serde_json::from_str::<PositionInfo>(json);
-        assert_eq!(result.unwrap().avg_price, Some(27464.50441675));
+        assert_eq!(result.unwrap().cum_realised_pnl, Some(-831.1052256));
     }
 }
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -1759,11 +1759,11 @@ pub struct Orders {
     #[serde(with = "string_to_float")]
     pub trigger_price: f64,
 
-    #[serde(with = "string_to_float")]
-    pub take_profit: f64,
+    #[serde(with = "string_to_float_optional")]
+    pub take_profit: Option<f64>,
 
-    #[serde(with = "string_to_float")]
-    pub stop_loss: f64,
+    #[serde(with = "string_to_float_optional")]
+    pub stop_loss: Option<f64>,
 
     pub tp_trigger_by: String,
     pub sl_trigger_by: String,

--- a/src/model.rs
+++ b/src/model.rs
@@ -2329,7 +2329,7 @@ pub struct PositionInfo {
     pub is_reduce_only: bool,
 
     #[serde(with = "string_to_u64_optional")]
-    pub mmr_sys_update_time: Option<u64>,
+    pub mmr_sys_updated_time: Option<u64>,
 
     #[serde(with = "string_to_u64_optional")]
     pub leverage_sys_updated_time: Option<u64>,
@@ -2376,7 +2376,7 @@ mod test_decode_position_info {
                 "cumRealisedPnl": "-0.00096902",
                 "seq": 5723621632,
                 "isReduceOnly": false,
-                "mmrSysUpdateTime": "1676538056444",
+                "mmrSysUpdatedTime": "1676538056444",
                 "leverageSysUpdatedTime": "1676538056333",
                 "sessionAvgPrice": "",
                 "createdTime": "1676538056258",
@@ -2386,7 +2386,7 @@ mod test_decode_position_info {
         let result = serde_json::from_str::<PositionInfo>(json);
         let result = result.unwrap();
         assert_eq!(result.cum_realised_pnl, Some(-0.00096902));
-        assert_eq!(result.mmr_sys_update_time, Some(1676538056444));
+        assert_eq!(result.mmr_sys_updated_time, Some(1676538056444));
         assert_eq!(result.leverage_sys_updated_time, Some(1676538056333));
         assert_eq!(result.created_time, 1676538056258);
         assert_eq!(result.updated_time, 1697673600012);

--- a/src/model.rs
+++ b/src/model.rs
@@ -1710,86 +1710,150 @@ pub struct OrderHistory {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct Orders {
-    #[serde(rename = "orderId")]
     pub order_id: String,
-    #[serde(rename = "orderLinkId")]
     pub order_link_id: String,
-    #[serde(rename = "blockTradeId")]
     pub block_trade_id: String,
     pub symbol: String,
+
     #[serde(with = "string_to_float")]
     pub price: f64,
+
     #[serde(with = "string_to_float")]
     pub qty: f64,
+
     pub side: Side,
-    #[serde(rename = "isLeverage", skip_serializing_if = "String::is_empty")]
+
+    #[serde(skip_serializing_if = "String::is_empty")]
     pub is_leverage: String,
-    #[serde(rename = "positionIdx")]
+
     pub position_idx: i32,
-    #[serde(rename = "orderStatus")]
     pub order_status: String,
-    #[serde(rename = "cancelType")]
     pub cancel_type: String,
-    #[serde(rename = "rejectReason")]
     pub reject_reason: String,
-    #[serde(rename = "avgPrice", with = "string_to_float")]
-    pub avg_price: f64,
-    #[serde(rename = "leavesQty", with = "string_to_float")]
+
+    #[serde(with = "string_to_float_optional")]
+    pub avg_price: Option<f64>,
+
+    #[serde(with = "string_to_float")]
     pub leaves_qty: f64,
-    #[serde(rename = "leavesValue", with = "string_to_float")]
+
+    #[serde(with = "string_to_float")]
     pub leaves_value: f64,
-    #[serde(rename = "cumExecQty", with = "string_to_float")]
+
+    #[serde(with = "string_to_float")]
     pub cum_exec_qty: f64,
-    #[serde(rename = "cumExecValue", with = "string_to_float")]
+
+    #[serde(with = "string_to_float")]
     pub cum_exec_value: f64,
-    #[serde(rename = "cumExecFee", with = "string_to_float")]
+
+    #[serde(with = "string_to_float")]
     pub cum_exec_fee: f64,
-    #[serde(rename = "timeInForce")]
+
     pub time_in_force: String,
-    #[serde(rename = "orderType")]
     pub order_type: OrderType,
-    #[serde(rename = "stopOrderType")]
     pub stop_order_type: String,
-    #[serde(rename = "orderIv", skip_serializing_if = "String::is_empty")]
+
+    #[serde(skip_serializing_if = "String::is_empty")]
     pub order_iv: String,
-    #[serde(rename = "triggerPrice", with = "string_to_float")]
+
+    #[serde(with = "string_to_float")]
     pub trigger_price: f64,
-    #[serde(rename = "takeProfit", with = "string_to_float")]
+
+    #[serde(with = "string_to_float")]
     pub take_profit: f64,
-    #[serde(rename = "stopLoss", with = "string_to_float")]
+
+    #[serde(with = "string_to_float")]
     pub stop_loss: f64,
-    #[serde(rename = "tpTriggerBy")]
+
     pub tp_trigger_by: String,
-    #[serde(rename = "slTriggerBy")]
     pub sl_trigger_by: String,
-    #[serde(rename = "triggerDirection")]
     pub trigger_direction: i32,
-    #[serde(rename = "triggerBy")]
     pub trigger_by: String,
-    #[serde(rename = "lastPriceOnCreated", with = "string_to_float")]
-    pub last_price_on_created: f64,
-    #[serde(rename = "reduceOnly")]
+
+    #[serde(with = "string_to_float_optional")]
+    pub last_price_on_created: Option<f64>,
+
     pub reduce_only: bool,
-    #[serde(rename = "closeOnTrigger")]
     pub close_on_trigger: bool,
-    #[serde(rename = "smpType")]
     pub smp_type: String,
-    #[serde(rename = "smpGroup")]
     pub smp_group: i32,
-    #[serde(rename = "smpOrderId", skip_serializing_if = "String::is_empty")]
+
+    #[serde(skip_serializing_if = "String::is_empty")]
     pub smp_order_id: String,
-    #[serde(rename = "tpslMode", skip_serializing_if = "String::is_empty")]
+
+    #[serde(skip_serializing_if = "String::is_empty")]
     pub tpsl_mode: String,
-    #[serde(rename = "tpLimitPrice", with = "string_to_float")]
-    pub tp_limit_price: f64,
-    #[serde(rename = "slLimitPrice", with = "string_to_float")]
-    pub sl_limit_price: f64,
-    #[serde(rename = "placeType", skip_serializing_if = "String::is_empty")]
+
+    #[serde(with = "string_to_float_optional")]
+    pub tp_limit_price: Option<f64>,
+
+    #[serde(with = "string_to_float_optional")]
+    pub sl_limit_price: Option<f64>,
+
+    #[serde(skip_serializing_if = "String::is_empty")]
     pub place_type: String,
+
     #[serde(with = "string_to_u64")]
     pub created_time: u64,
+
     #[serde(with = "string_to_u64")]
     pub updated_time: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_deserialize_orders() {
+        let json = r#"
+        {
+                "orderId": "fd4300ae-7847-404e-b947-b46980a4d140",
+                "orderLinkId": "test-000005",
+                "blockTradeId": "",
+                "symbol": "ETHUSDT",
+                "price": "1600.00",
+                "qty": "0.10",
+                "side": "Buy",
+                "isLeverage": "",
+                "positionIdx": 1,
+                "orderStatus": "New",
+                "cancelType": "UNKNOWN",
+                "rejectReason": "EC_NoError",
+                "avgPrice": "0",
+                "leavesQty": "0.10",
+                "leavesValue": "160",
+                "cumExecQty": "0.00",
+                "cumExecValue": "0",
+                "cumExecFee": "0",
+                "timeInForce": "GTC",
+                "orderType": "Limit",
+                "stopOrderType": "UNKNOWN",
+                "orderIv": "",
+                "triggerPrice": "0.00",
+                "takeProfit": "2500.00",
+                "stopLoss": "1500.00",
+                "tpTriggerBy": "LastPrice",
+                "slTriggerBy": "LastPrice",
+                "triggerDirection": 0,
+                "triggerBy": "UNKNOWN",
+                "lastPriceOnCreated": "",
+                "reduceOnly": false,
+                "closeOnTrigger": false,
+                "smpType": "None",
+                "smpGroup": 0,
+                "smpOrderId": "",
+                "tpslMode": "Full",
+                "tpLimitPrice": "",
+                "slLimitPrice": "",
+                "placeType": "",
+                "createdTime": "1684738540559",
+                "updatedTime": "1684738540561"
+            }
+        "#;
+        let order: Orders = serde_json::from_str(json).unwrap();
+        assert_eq!(order.order_id, "fd4300ae-7847-404e-b947-b46980a4d140");
+    }
 }
 
 #[derive(Clone, Default)]


### PR DESCRIPTION
PositionInfo struct failed to JSON decode since it can return `""` - but you were using `string_to_float` which fails for empty string. I've added two new deserializers we can use, one which defaults `""` -> `0` and one which defaults to `None` in case of `""`.

I've also ensured to return more details about WHY reqwest fails to Serde deserialize response, so instead of `"error decoding response body"` error message we will see e.g. `"Json decode error parsing response as PositionInfo failed to parse empty string as f64"`