### PR TITLE
fix bugs with start and end time for historic endpoints. Increase precision

### DIFF
--- a/src/account.rs
+++ b/src/account.rs
@@ -22,7 +22,6 @@ pub struct AccountManager {
 }
 
 impl AccountManager {
-    
     /// Fetches the wallet balance for a specific account and optional coin.
     ///
     /// # Arguments
@@ -66,7 +65,6 @@ impl AccountManager {
         Ok(response)
     }
 
-    
     /// Upgrades the current account to UTA.
     ///
     /// This function sends a POST request to the Bybit API to upgrade the current account to UTA
@@ -95,7 +93,6 @@ impl AccountManager {
         Ok(response)
     }
 
-
     /// Retrieves the borrow history for the current account.
     ///
     /// This function sends a signed GET request to the Bybit API to retrieve the borrow history for
@@ -120,19 +117,17 @@ impl AccountManager {
         }
 
         // If the start time is specified, convert it to milliseconds and insert it into the parameters.
-        if let Some(end_str) = req.start_time.as_ref().map(|s| s.as_ref()) {
-            let end_millis = date_to_milliseconds(end_str);
+        if let Some(start_time) = req.start_time {
             parameters
                 .entry("startTime".to_owned())
-                .or_insert_with(|| end_millis.into());
+                .or_insert_with(|| start_time.into());
         }
 
         // If the end time is specified, convert it to milliseconds and insert it into the parameters.
-        if let Some(end_str) = req.end_time.as_ref().map(|s| s.as_ref()) {
-            let end_millis = date_to_milliseconds(end_str);
+        if let Some(end_time) = req.end_time {
             parameters
                 .entry("endTime".to_owned())
-                .or_insert_with(|| end_millis.into());
+                .or_insert_with(|| end_time.into());
         }
 
         // If the limit is specified, insert it into the parameters.
@@ -202,7 +197,10 @@ impl AccountManager {
         // Insert the coin parameter.
         parameters.insert("coin".into(), coin.into());
         // Insert the collateral switch parameter based on the switch value.
-        parameters.insert("collateralSwitch".into(), if switch { "ON".into() } else { "OFF".into() });
+        parameters.insert(
+            "collateralSwitch".into(),
+            if switch { "ON".into() } else { "OFF".into() },
+        );
         // Build the request using the parameters.
         let request = build_json_request(&parameters);
         // Send the signed request to the Bybit API and await the response.
@@ -296,7 +294,6 @@ impl AccountManager {
         // Return the response.
         Ok(response)
     }
-
 
     /// Retrieves the fee rate for a given market category and symbol.
     ///
@@ -416,19 +413,17 @@ impl AccountManager {
         }
 
         // Add the start time to the request parameters if it is specified.
-        if let Some(start_str) = req.start_time.as_ref().map(|s| s.as_ref()) {
-            let start_millis = date_to_milliseconds(start_str);
+        if let Some(start_time) = req.start_time {
             parameters
                 .entry("startTime".to_owned())
-                .or_insert_with(|| start_millis.into());
+                .or_insert_with(|| start_time.into());
         }
 
         // Add the end time to the request parameters if it is specified.
-        if let Some(end_str) = req.end_time.as_ref().map(|s| s.as_ref()) {
-            let end_millis = date_to_milliseconds(end_str);
+        if let Some(end_time) = req.end_time {
             parameters
                 .entry("endTime".to_owned())
-                .or_insert_with(|| end_millis.into());
+                .or_insert_with(|| end_time.into());
         }
 
         // Add the limit to the request parameters if it is specified.

--- a/src/market.rs
+++ b/src/market.rs
@@ -488,17 +488,17 @@ impl MarketData {
         };
         parameters.insert("category".into(), category_value.into());
         parameters.insert("symbol".into(), req.symbol.into());
-        if let Some(start_str) = req.start_time.as_ref().map(|s| s.as_ref()) {
-            let start_millis = date_to_milliseconds(start_str);
+
+        if let Some(start_time) = req.start_time {
             parameters
                 .entry("startTime".to_owned())
-                .or_insert_with(|| start_millis.to_string());
+                .or_insert_with(|| start_time.to_string());
         }
-        if let Some(end_str) = req.end_time.as_ref().map(|s| s.as_ref()) {
-            let end_millis = date_to_milliseconds(end_str);
+
+        if let Some(end_time) = req.end_time {
             parameters
                 .entry("endTime".to_owned())
-                .or_insert_with(|| end_millis.to_string());
+                .or_insert_with(|| end_time.to_string());
         }
 
         if let Some(l) = req.limit {

--- a/src/model.rs
+++ b/src/model.rs
@@ -645,8 +645,8 @@ pub struct SpotTicker {
 pub struct FundingHistoryRequest<'a> {
     pub category: Category,
     pub symbol: Cow<'a, str>,
-    pub start_time: Option<Cow<'a, str>>,
-    pub end_time: Option<Cow<'a, str>>,
+    pub start_time: Option<u64>,
+    pub end_time: Option<u64>,
     pub limit: Option<u64>,
 }
 impl<'a> FundingHistoryRequest<'a> {
@@ -656,15 +656,15 @@ impl<'a> FundingHistoryRequest<'a> {
     pub fn new(
         category: Category,
         symbol: &'a str,
-        start_time: Option<&'a str>,
-        end_time: Option<&'a str>,
+        start_time: Option<u64>,
+        end_time: Option<u64>,
         limit: Option<u64>,
     ) -> FundingHistoryRequest<'a> {
         FundingHistoryRequest {
             category,
             symbol: Cow::Borrowed(symbol),
-            start_time: start_time.map(|s| Cow::Borrowed(s)),
-            end_time: end_time.map(|s| Cow::Borrowed(s)),
+            start_time,
+            end_time,
             limit,
         }
     }
@@ -1635,8 +1635,8 @@ pub struct OrderHistoryRequest<'a> {
     pub order_link_id: Option<Cow<'a, str>>,
     pub order_filter: Option<Cow<'a, str>>,
     pub order_status: Option<Cow<'a, str>>,
-    pub start_time: Option<Cow<'a, str>>,
-    pub end_time: Option<Cow<'a, str>>,
+    pub start_time: Option<u64>,
+    pub end_time: Option<u64>,
     pub limit: Option<u64>,
 }
 
@@ -1665,8 +1665,8 @@ impl<'a> OrderHistoryRequest<'a> {
         order_link_id: Option<&'a str>,
         order_filter: Option<&'a str>,
         order_status: Option<&'a str>,
-        start_time: Option<&'a str>,
-        end_time: Option<&'a str>,
+        start_time: Option<u64>,
+        end_time: Option<u64>,
         limit: Option<u64>,
     ) -> Self {
         Self {
@@ -1678,8 +1678,8 @@ impl<'a> OrderHistoryRequest<'a> {
             order_link_id: order_link_id.map(Cow::Borrowed),
             order_filter: order_filter.map(Cow::Borrowed),
             order_status: order_status.map(Cow::Borrowed),
-            start_time: start_time.map(Cow::Borrowed),
-            end_time: end_time.map(Cow::Borrowed),
+            start_time,
+            end_time,
             limit,
         }
     }
@@ -2061,8 +2061,8 @@ pub struct TradeHistoryRequest<'a> {
     pub order_id: Option<Cow<'a, str>>,
     pub order_link_id: Option<Cow<'a, str>>,
     pub base_coin: Option<Cow<'a, str>>,
-    pub start_time: Option<Cow<'a, str>>,
-    pub end_time: Option<Cow<'a, str>>,
+    pub start_time: Option<u64>,
+    pub end_time: Option<u64>,
     pub exec_type: Option<Cow<'a, str>>,
     pub limit: Option<u64>,
 }
@@ -2087,8 +2087,8 @@ impl<'a> TradeHistoryRequest<'a> {
         order_id: Option<&'a str>,
         order_link_id: Option<&'a str>,
         base_coin: Option<&'a str>,
-        start_time: Option<&'a str>,
-        end_time: Option<&'a str>,
+        start_time: Option<u64>,
+        end_time: Option<u64>,
         exec_type: Option<&'a str>,
         limit: Option<u64>,
     ) -> TradeHistoryRequest<'a> {
@@ -2098,8 +2098,8 @@ impl<'a> TradeHistoryRequest<'a> {
             order_id: order_id.map(|s| Cow::Borrowed(s)),
             order_link_id: order_link_id.map(|s| Cow::Borrowed(s)),
             base_coin: base_coin.map(|s| Cow::Borrowed(s)),
-            start_time: start_time.map(|s| Cow::Borrowed(s)),
-            end_time: end_time.map(|s| Cow::Borrowed(s)),
+            start_time,
+            end_time,
             exec_type: exec_type.map(|s| Cow::Borrowed(s)),
             limit,
         }
@@ -2875,8 +2875,8 @@ pub struct AddReduceMarginResult {
 pub struct ClosedPnlRequest<'a> {
     pub category: Category,
     pub symbol: Option<Cow<'a, str>>,
-    pub start_time: Option<Cow<'a, str>>,
-    pub end_time: Option<Cow<'a, str>>,
+    pub start_time: Option<u64>,
+    pub end_time: Option<u64>,
     pub limit: Option<u64>,
 }
 
@@ -2884,15 +2884,15 @@ impl<'a> ClosedPnlRequest<'a> {
     pub fn new(
         category: Category,
         symbol: Option<&'a str>,
-        start_time: Option<&'a str>,
-        end_time: Option<&'a str>,
+        start_time: Option<u64>,
+        end_time: Option<u64>,
         limit: Option<u64>,
     ) -> Self {
         Self {
             category,
             symbol: symbol.map(|s| Cow::Borrowed(s)),
-            start_time: start_time.map(|s| Cow::Borrowed(s)),
-            end_time: end_time.map(|s| Cow::Borrowed(s)),
+            start_time,
+            end_time,
             limit,
         }
     }
@@ -3009,8 +3009,8 @@ pub struct MovePositionResult {
 pub struct MoveHistoryRequest<'a> {
     pub category: Option<Category>,
     pub symbol: Option<Cow<'a, str>>,
-    pub start_time: Option<Cow<'a, str>>,
-    pub end_time: Option<Cow<'a, str>>,
+    pub start_time: Option<u64>,
+    pub end_time: Option<u64>,
     pub status: Option<Cow<'a, str>>,
     pub block_trade_id: Option<Cow<'a, str>>,
     pub limit: Option<Cow<'a, str>>,
@@ -3020,8 +3020,8 @@ impl<'a> MoveHistoryRequest<'a> {
     pub fn new(
         category: Option<Category>,
         symbol: Option<&'a str>,
-        start_time: Option<&'a str>,
-        end_time: Option<&'a str>,
+        start_time: Option<u64>,
+        end_time: Option<u64>,
         status: Option<&'a str>,
         block_trade_id: Option<&'a str>,
         limit: Option<&'a str>,
@@ -3029,8 +3029,8 @@ impl<'a> MoveHistoryRequest<'a> {
         Self {
             category,
             symbol: symbol.map(|s| Cow::Borrowed(s)),
-            start_time: start_time.map(|s| Cow::Borrowed(s)),
-            end_time: end_time.map(|s| Cow::Borrowed(s)),
+            start_time,
+            end_time,
             status: status.map(|s| Cow::Borrowed(s)),
             block_trade_id: block_trade_id.map(|s| Cow::Borrowed(s)),
             limit: limit.map(|s| Cow::Borrowed(s)),
@@ -3147,22 +3147,22 @@ pub struct UnifiedUpdateMsg {
 #[derive(Clone, Debug, Default)]
 pub struct BorrowHistoryRequest<'a> {
     pub coin: Option<Cow<'a, str>>,
-    pub start_time: Option<Cow<'a, str>>,
-    pub end_time: Option<Cow<'a, str>>,
+    pub start_time: Option<u64>,
+    pub end_time: Option<u64>,
     pub limit: Option<Cow<'a, str>>,
 }
 
 impl<'a> BorrowHistoryRequest<'a> {
     pub fn new(
         coin: Option<&'a str>,
-        start_time: Option<&'a str>,
-        end_time: Option<&'a str>,
+        start_time: Option<u64>,
+        end_time: Option<u64>,
         limit: Option<&'a str>,
     ) -> Self {
         Self {
             coin: coin.map(|s| Cow::Borrowed(s)),
-            start_time: start_time.map(|s| Cow::Borrowed(s)),
-            end_time: end_time.map(|s| Cow::Borrowed(s)),
+            start_time,
+            end_time,
             limit: limit.map(|s| Cow::Borrowed(s)),
         }
     }
@@ -3367,8 +3367,8 @@ pub struct TransactionLogRequest<'a> {
     pub currency: Option<Cow<'a, str>>,
     pub base_coin: Option<Cow<'a, str>>,
     pub log_type: Option<Cow<'a, str>>,
-    pub start_time: Option<Cow<'a, str>>,
-    pub end_time: Option<Cow<'a, str>>,
+    pub start_time: Option<u64>,
+    pub end_time: Option<u64>,
     pub limit: Option<u32>,
 }
 
@@ -3379,8 +3379,8 @@ impl<'a> TransactionLogRequest<'a> {
         currency: Option<&'a str>,
         base_coin: Option<&'a str>,
         log_type: Option<&'a str>,
-        start_time: Option<&'a str>,
-        end_time: Option<&'a str>,
+        start_time: Option<u64>,
+        end_time: Option<u64>,
         limit: Option<u32>,
     ) -> Self {
         Self {
@@ -3389,8 +3389,8 @@ impl<'a> TransactionLogRequest<'a> {
             currency: currency.map(|s| Cow::Borrowed(s)),
             base_coin: base_coin.map(|s| Cow::Borrowed(s)),
             log_type: log_type.map(|s| Cow::Borrowed(s)),
-            start_time: start_time.map(|s| Cow::Borrowed(s)),
-            end_time: end_time.map(|s| Cow::Borrowed(s)),
+            start_time,
+            end_time,
             limit,
         }
     }

--- a/src/position.rs
+++ b/src/position.rs
@@ -7,11 +7,10 @@ use crate::client::Client;
 use crate::errors::BybitError;
 use crate::model::{
     AddMarginRequest, AddMarginResponse, AddReduceMarginRequest, AddReduceMarginResponse,
-    ChangeMarginRequest, ChangeMarginResponse, ClosedPnlRequest,
-    ClosedPnlResponse, InfoResponse, LeverageRequest, LeverageResponse,
-    MarginModeRequest, MarginModeResponse, MoveHistoryRequest, MoveHistoryResponse,
-    MovePositionRequest, MovePositionResponse, PositionRequest, SetRiskLimit, SetRiskLimitResponse, TradingStopRequest,
-    TradingStopResponse,
+    ChangeMarginRequest, ChangeMarginResponse, ClosedPnlRequest, ClosedPnlResponse, InfoResponse,
+    LeverageRequest, LeverageResponse, MarginModeRequest, MarginModeResponse, MoveHistoryRequest,
+    MoveHistoryResponse, MovePositionRequest, MovePositionResponse, PositionRequest, SetRiskLimit,
+    SetRiskLimitResponse, TradingStopRequest, TradingStopResponse,
 };
 use crate::util::{build_json_request, build_request, date_to_milliseconds};
 
@@ -366,17 +365,15 @@ impl PositionManager {
             parameters.insert("symbol".into(), v.into());
         }
 
-        if let Some(start_str) = req.start_time.as_ref().map(|s| s.as_ref()) {
-            let start_millis = date_to_milliseconds(start_str);
+        if let Some(start_time) = req.start_time {
             parameters
-                .entry("end".to_owned())
-                .or_insert_with(|| start_millis.to_string().into());
+                .entry("startTime".to_owned())
+                .or_insert_with(|| start_time.to_string().into());
         }
-        if let Some(end_str) = req.end_time.as_ref().map(|s| s.as_ref()) {
-            let end_millis = date_to_milliseconds(end_str);
+        if let Some(end_time) = req.end_time {
             parameters
-                .entry("end".to_owned())
-                .or_insert_with(|| end_millis.to_string().into());
+                .entry("endTime".to_owned())
+                .or_insert_with(|| end_time.to_string().into());
         }
         if let Some(v) = req.limit {
             parameters.insert("limit".into(), v.into());
@@ -452,19 +449,17 @@ impl PositionManager {
         }
 
         // If the start time is specified, convert it to milliseconds and insert it into the parameters.
-        if let Some(start_str) = req.start_time.as_ref().map(|s| s.as_ref()) {
-            let start_millis = date_to_milliseconds(start_str);
+        if let Some(start_time) = req.start_time {
             parameters
-                .entry("end".to_owned())
-                .or_insert_with(|| start_millis.to_string().into());
+                .entry("startTime".to_owned())
+                .or_insert_with(|| start_time.to_string().into());
         }
 
         // If the end time is specified, convert it to milliseconds and insert it into the parameters.
-        if let Some(end_str) = req.end_time.as_ref().map(|s| s.as_ref()) {
-            let end_millis = date_to_milliseconds(end_str);
+        if let Some(end_time) = req.end_time {
             parameters
-                .entry("end".to_owned())
-                .or_insert_with(|| end_millis.to_string().into());
+                .entry("endTime".to_owned())
+                .or_insert_with(|| end_time.to_string().into());
         }
 
         // If the status is specified, add it to the parameters.

--- a/src/trade.rs
+++ b/src/trade.rs
@@ -280,11 +280,9 @@ impl Trader {
         req.order_status
             .map(|order_status| parameters.insert("orderStatus".into(), order_status.into()));
         req.start_time
-            .and_then(|start_time| Some(date_to_milliseconds(start_time.as_ref())))
-            .map(|start_millis| parameters.insert("startTime".into(), start_millis.to_string()));
+            .map(|start_time| parameters.insert("startTime".into(), start_time.to_string()));
         req.end_time
-            .and_then(|end_time| Some(date_to_milliseconds(end_time.as_ref())))
-            .map(|end_millis| parameters.insert("endTime".into(), end_millis.to_string()));
+            .map(|end_time| parameters.insert("endTime".into(), end_time.to_string()));
         req.limit
             .map(|limit| parameters.insert("limit".into(), limit.to_string()));
 
@@ -337,13 +335,11 @@ impl Trader {
 
         // Add the start time to the request parameters if it is specified
         req.start_time
-            .and_then(|start_time| Some(date_to_milliseconds(start_time.as_ref())))
-            .map(|start_millis| parameters.insert("startTime".into(), start_millis.to_string()));
+            .map(|start_time| parameters.insert("startTime".into(), start_time.to_string()));
 
         // Add the end time to the request parameters if it is specified
         req.end_time
-            .and_then(|end_time| Some(date_to_milliseconds(end_time.as_ref())))
-            .map(|end_millis| parameters.insert("endTime".into(), end_millis.to_string()));
+            .map(|end_time| parameters.insert("endTime".into(), end_time.to_string()));
 
         // Add the limit to the request parameters if it is specified
         req.limit


### PR DESCRIPTION
Change from String representation of `start_time` and `end_time` using day level (mm-dd-yy) into unix timestamp, for better precision.

Fixed many bugs with usages of:
* `"end"` (incorrect key) instead of `"endTime"` (correct key)
* `"start"` (incorrect key) instead of `"startTime"` (correct key)

Also fix bugs where 
* `end_time` (incorrect) for `"startTime"` was used instead of `start_time` (correct)
* `start_time ` (incorrect) for `"endTime"` was used instead of `end_time ` (correct)

