### PR TITLE
Refactor response structures and enhance Kline tests

### DIFF
--- a/src/market.rs
+++ b/src/market.rs
@@ -260,22 +260,23 @@ impl MarketData {
             .await?;
         Ok(response)
     }
-    /// Retrieves a list of futures instruments based on the specified filters.
+    /// Retrieves a list of instruments (Futures or Spot) based on the specified filters.
     ///
-    /// This function queries the exchange for futures instruments, optionally filtered by the provided
-    /// symbol, status, base coin, and result count limit.
+    /// This function queries the exchange for instruments, optionally filtered by the provided
+    /// symbol, status, base coin, and result count limit. It supports both Futures and Spot instruments,
+    /// returning results encapsulated in the `InstrumentInfo` enum.
     ///
     /// # Arguments
     ///
-    /// * `symbol` - An optional filter to specify the symbol of the futures instruments.
+    /// * `symbol` - An optional filter to specify the symbol of the instruments.
     /// * `status` - An optional boolean to indicate if only instruments with trading status should be retrieved.
-    /// * `base_coin` - An optional filter for the base coin of the futures instruments.
-    /// * `limit` - An optional limit on the number of futures instruments to be retrieved.
+    /// * `base_coin` - An optional filter for the base coin of the instruments.
+    /// * `limit` - An optional limit on the number of instruments to be retrieved.
     ///
     /// # Returns
     ///
-    /// A `Result<Vec<FuturesInstrument>, Error>` where the `Ok` variant contains the filtered list of
-    /// futures instruments, and the `Err` variant contains an error if the request fails or if the response
+    /// A `Result<InstrumentInfoResponse, Error>` where the `Ok` variant contains the filtered list of
+    /// instruments (Futures or Spot), and the `Err` variant contains an error if the request fails or if the response
     /// parsing encounters an issue.
     pub async fn get_instrument_info<'b>(
         &self,
@@ -345,16 +346,16 @@ impl MarketData {
 
         Ok(response)
     }
-
-    /// Asynchronously retrieves spot tickers based on the provided symbol.
+    /// Asynchronously retrieves tickers based on the provided symbol and category.
     ///
     /// # Arguments
     ///
     /// * `symbol` - An optional reference to a string representing the symbol.
+    /// * `category` - The market category (e.g., Linear, Inverse, Spot) for which tickers are to be retrieved.
     ///
     /// # Returns
     ///
-    /// A Result containing a vector of SpotTicker objects, or an error if the retrieval fails.
+    /// A Result containing a vector of Ticker objects, or an error if the retrieval fails.
     pub async fn get_tickers(
         &self,
         symbol: Option<&str>,

--- a/src/market.rs
+++ b/src/market.rs
@@ -3,12 +3,12 @@ use crate::client::Client;
 use crate::errors::BybitError;
 use crate::model::{
     Category, DeliveryPriceResponse, FundingHistoryRequest, FundingRateResponse,
-    FuturesInstrumentsInfoResponse, FuturesTickersResponse, HistoricalVolatilityRequest,
+    InstrumentInfoResponse, FuturesTickersResponse, HistoricalVolatilityRequest,
     HistoricalVolatilityResponse, IndexPriceKlineResponse, InstrumentRequest, InsuranceResponse,
     KlineRequest, KlineResponse, LongShortRatioResponse, MarkPriceKlineResponse,
     OpenInterestRequest, OpeninterestResponse, OptionsInstrument, OrderBookResponse,
     OrderbookRequest, PremiumIndexPriceKlineResponse, RecentTradesRequest, RecentTradesResponse,
-    RiskLimitRequest, RiskLimitResponse, SpotInstrumentsInfoResponse, SpotTickersResponse,
+    RiskLimitRequest, RiskLimitResponse, SpotTickersResponse,
 };
 use crate::util::{build_request, date_to_milliseconds};
 
@@ -283,10 +283,10 @@ impl MarketData {
     /// A `Result<Vec<FuturesInstrument>, Error>` where the `Ok` variant contains the filtered list of
     /// futures instruments, and the `Err` variant contains an error if the request fails or if the response
     /// parsing encounters an issue.
-    pub async fn get_futures_instrument_info<'b>(
+    pub async fn get_instrument_info<'b>(
         &self,
         req: InstrumentRequest<'b>,
-    ) -> Result<FuturesInstrumentsInfoResponse, BybitError> {
+    ) -> Result<InstrumentInfoResponse, BybitError> {
         let mut parameters: BTreeMap<String, String> = BTreeMap::new();
         let category_value = match req.category {
             Category::Linear => "linear",
@@ -311,53 +311,14 @@ impl MarketData {
             parameters.insert("limit".into(), l.to_string());
         }
         let request = build_request(&parameters);
-        let response: FuturesInstrumentsInfoResponse = self
+        let response: InstrumentInfoResponse = self
             .client
             .get(API::Market(Market::InstrumentsInfo), Some(request))
             .await?;
         Ok(response)
     }
 
-    /// Fetches details for spot instruments based on provided filters.
-    ///
-    /// # Arguments
-    ///
-    /// * `symbol` - An optional string to filter instruments by their symbol.
-    /// * `status` - A boolean to include only instruments that are currently trading when set to `true`.
-    /// * `base_coin` - An optional string to filter instruments by their base coin.
-    /// * `limit` - An optional usize to limit the number of instruments returned.
-    ///
-    /// # Returns
-    ///
-    /// A `Result` containing a list of `SpotInstrument` instances matching the filters, or an error on failure.
-    ///
-    pub async fn get_spot_instrument_info<'b>(
-        &self,
-        req: InstrumentRequest<'_>,
-    ) -> Result<SpotInstrumentsInfoResponse, BybitError> {
-        let mut parameters: BTreeMap<String, String> = BTreeMap::new();
-        parameters.insert("category".into(), "Spot".into());
-        if let Some(symbol) = req.symbol {
-            parameters.insert("symbol".into(), symbol.into());
-        }
-        if let Some(status) = req.status {
-            if status {
-                parameters.insert("status".into(), "Trading".into());
-            }
-        }
-        if let Some(base_coin) = req.base_coin {
-            parameters.insert("baseCoin".into(), base_coin.into());
-        }
-        if let Some(l) = req.limit {
-            parameters.insert("limit".into(), l.to_string());
-        }
-        let request = build_request(&parameters);
-        let response: SpotInstrumentsInfoResponse = self
-            .client
-            .get(API::Market(Market::InstrumentsInfo), Some(request))
-            .await?;
-        Ok(response)
-    }
+    
 
     pub async fn get_options_instrument_info<'b>(
         &self,

--- a/src/model.rs
+++ b/src/model.rs
@@ -15,12 +15,9 @@ pub struct Empty {}
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct ServerTimeResponse {
-    #[serde(rename = "retCode")]
     pub ret_code: i16,
-    #[serde(rename = "retMsg")]
     pub ret_msg: String,
     pub result: ServerTime,
-    #[serde(rename = "retExtInfo")]
     pub ret_ext_info: Empty,
     pub time: u64,
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -15,7 +15,7 @@ pub struct Empty {}
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct ServerTimeResponse {
-    pub ret_code: i16,
+    pub ret_code: i32,
     pub ret_msg: String,
     pub result: ServerTime,
     pub ret_ext_info: Empty,
@@ -66,7 +66,7 @@ impl<'a> KlineRequest<'a> {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct KlineResponse {
-    pub ret_code: i16,
+    pub ret_code: i32,
     pub ret_msg: String,
     pub result: KlineSummary,
     pub ret_ext_info: Empty,
@@ -97,7 +97,7 @@ pub struct Kline {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct MarkPriceKlineResponse {
-    pub ret_code: i16,
+    pub ret_code: i32,
     pub ret_msg: String,
     pub result: MarkPriceKlineSummary,
     pub ret_ext_info: Empty,
@@ -126,7 +126,7 @@ pub struct MarkPriceKline {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct IndexPriceKlineResponse {
-    pub ret_code: i16,
+    pub ret_code: i32,
     pub ret_msg: String,
     pub result: IndexPriceKlineSummary,
     pub ret_ext_info: Empty,
@@ -155,7 +155,7 @@ pub struct IndexPriceKline {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct PremiumIndexPriceKlineResponse {
-    pub ret_code: i16,
+    pub ret_code: i32,
     pub ret_msg: String,
     pub result: PremiumIndexPriceKlineSummary,
     pub ret_ext_info: Empty,
@@ -213,7 +213,7 @@ impl<'a> InstrumentRequest<'a> {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct InstrumentInfoResponse {
-    pub ret_code: i16,
+    pub ret_code: i32,
     pub ret_msg: String,
     pub result: InstrumentInfo,
     pub ret_ext_info: Empty,
@@ -265,7 +265,6 @@ pub struct FuturesInstrument {
     // #[serde(rename = "preListingInfo")]
     // pub pre_listing_info: PreListingInfo,
 }
-
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
@@ -381,9 +380,7 @@ pub struct LotSizeFilter {
     pub max_order_amt: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub qty_step: Option<String>,
-    #[serde(
-        skip_serializing_if = "Option::is_none"
-    )]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub post_only_max_order_qty: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub min_notional_value: Option<String>,
@@ -412,7 +409,7 @@ impl<'a> OrderbookRequest<'a> {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct OrderBookResponse {
-    pub ret_code: i16,
+    pub ret_code: i32,
     pub ret_msg: String,
     pub result: OrderBook,
     pub ret_ext_info: Empty,
@@ -462,11 +459,10 @@ impl Ask {
     }
 }
 
-
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct TickerResponse {
-    pub ret_code: i16,
+    pub ret_code: i32,
     pub ret_msg: String,
     pub result: TickersInfo,
     pub ret_ext_info: Empty,
@@ -479,7 +475,6 @@ pub struct TickersInfo {
     pub category: String,
     pub list: Vec<TickerData>,
 }
-
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(untagged)]
@@ -600,7 +595,7 @@ impl<'a> FundingHistoryRequest<'a> {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct FundingRateResponse {
-    pub ret_code: i16,
+    pub ret_code: i32,
     pub ret_msg: String,
     pub result: FundingRateSummary,
     pub ret_ext_info: Empty,
@@ -653,7 +648,7 @@ impl<'a> RecentTradesRequest<'a> {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct RecentTradesResponse {
-    pub ret_code: i16,
+    pub ret_code: i32,
     pub ret_msg: String,
     pub result: RecentTrades,
     pub ret_ext_info: Empty,
@@ -717,7 +712,7 @@ impl<'a> OpenInterestRequest<'a> {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct OpeninterestResponse {
-    pub ret_code: i16,
+    pub ret_code: i32,
     pub ret_msg: String,
     pub result: OpenInterestSummary,
     pub ret_ext_info: Empty,
@@ -773,7 +768,7 @@ impl<'a> HistoricalVolatilityRequest<'a> {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct HistoricalVolatilityResponse {
-    pub ret_code: i16,
+    pub ret_code: i32,
     pub ret_msg: String,
     pub category: String,
     pub result: Vec<HistoricalVolatility>,
@@ -792,7 +787,7 @@ pub struct HistoricalVolatility {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct InsuranceResponse {
-    pub ret_code: i16,
+    pub ret_code: i32,
     pub ret_msg: String,
     pub result: InsuranceSummary,
     pub ret_ext_info: Empty,
@@ -836,7 +831,7 @@ impl<'a> RiskLimitRequest<'a> {
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct RiskLimitResponse {
-    pub ret_code: i16,
+    pub ret_code: i32,
     pub ret_msg: String,
     pub result: RiskLimitSummary,
     pub ret_ext_info: Empty,
@@ -853,7 +848,7 @@ pub struct RiskLimitSummary {
 pub struct RiskLimit {
     pub id: u64,
     pub symbol: String,
-    #[serde( with = "string_to_float")]
+    #[serde(with = "string_to_float")]
     pub risk_limit_value: f64,
     #[serde(with = "string_to_float")]
     pub maintainence_margin: f64,
@@ -866,7 +861,7 @@ pub struct RiskLimit {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct DeliveryPriceResponse {
-    pub ret_code: i16,
+    pub ret_code: i32,
     pub ret_msg: String,
     pub result: DeliveryPriceSummary,
     pub ret_ext_info: Empty,
@@ -894,7 +889,7 @@ pub struct DeliveryPrice {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct LongShortRatioResponse {
-    pub ret_code: i16,
+    pub ret_code: i32,
     pub ret_msg: String,
     pub result: LongShortRatioSummary,
     pub ret_ext_info: Empty,
@@ -1332,7 +1327,7 @@ impl<'a> OrderRequest<'a> {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct AmendOrderResponse {
-    pub ret_code: i16,
+    pub ret_code: i32,
     pub ret_msg: String,
     pub result: OrderStatus,
     pub ret_ext_info: Empty,
@@ -1431,7 +1426,7 @@ pub struct CancelOrderRequest<'a> {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct CancelOrderResponse {
-    pub ret_code: i16,
+    pub ret_code: i32,
     pub ret_msg: String,
     pub result: OrderStatus,
     pub ret_ext_info: Empty,
@@ -1497,7 +1492,7 @@ impl<'a> OpenOrdersRequest<'a> {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct OpenOrdersResponse {
-    pub ret_code: i16,
+    pub ret_code: i32,
     pub ret_msg: String,
     pub result: OrderHistory,
     pub ret_ext_info: Empty,
@@ -1514,7 +1509,7 @@ pub struct OrderStatus {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct OrderResponse {
-    pub ret_code: i16,
+    pub ret_code: i32,
     pub ret_msg: String,
     pub result: OrderStatus,
     pub ret_ext_info: Empty,
@@ -1584,7 +1579,7 @@ impl<'a> OrderHistoryRequest<'a> {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct OrderHistoryResponse {
-    pub ret_code: i16,
+    pub ret_code: i32,
     pub ret_msg: String,
     pub result: OrderHistory,
     #[serde(rename = "retExtInfo")]
@@ -1597,7 +1592,7 @@ pub struct OrderHistoryResponse {
 pub struct OrderHistory {
     pub category: String,
     pub list: Vec<Order>,
-    #[serde( skip_serializing_if = "String::is_empty")]
+    #[serde(skip_serializing_if = "String::is_empty")]
     pub next_page_cursor: String,
 }
 
@@ -1834,12 +1829,11 @@ impl<'a> CancelallRequest<'a> {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct CancelallResponse {
-    
-    pub ret_code: i16,
-    
+    pub ret_code: i32,
+
     pub ret_msg: String,
     pub result: CancelledList,
-    
+
     pub ret_ext_info: Empty,
     pub time: u64,
 }
@@ -1853,7 +1847,7 @@ pub struct CancelledList {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct TradeHistoryResponse {
-    pub ret_code: i16,
+    pub ret_code: i32,
     pub ret_msg: String,
     pub result: TradeHistorySummary,
     pub ret_ext_info: Empty,
@@ -1863,7 +1857,7 @@ pub struct TradeHistoryResponse {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct TradeHistorySummary {
-    #[serde( skip_serializing_if = "String::is_empty")]
+    #[serde(skip_serializing_if = "String::is_empty")]
     pub next_page_cursor: String,
     pub category: String,
     pub list: Vec<TradeHistory>,
@@ -1873,47 +1867,32 @@ pub struct TradeHistorySummary {
 pub struct TradeHistory {
     pub symbol: String,
     pub order_type: String,
-    #[serde(
-        default,
-        skip_serializing_if = "String::is_empty"
-    )]
+    #[serde(default, skip_serializing_if = "String::is_empty")]
     pub underlying_price: String,
-    #[serde(
-        default,
-        skip_serializing_if = "String::is_empty"
-    )]
+    #[serde(default, skip_serializing_if = "String::is_empty")]
     pub order_link_id: String,
     pub side: String,
-    #[serde(
-        default,
-        skip_serializing_if = "String::is_empty"
-    )]
+    #[serde(default, skip_serializing_if = "String::is_empty")]
     pub index_price: String,
     pub order_id: String,
     pub stop_order_type: String,
     pub leaves_qty: String,
     pub exec_time: String,
-    #[serde(
-        default,
-        skip_serializing_if = "String::is_empty"
-    )]
+    #[serde(default, skip_serializing_if = "String::is_empty")]
     pub fee_currency: String,
     pub is_maker: bool,
     pub exec_fee: String,
     pub fee_rate: String,
     pub exec_id: String,
-    #[serde( default, skip_serializing_if = "String::is_empty")]
+    #[serde(default, skip_serializing_if = "String::is_empty")]
     pub trade_iv: String,
-    #[serde(
-        default,
-        skip_serializing_if = "String::is_empty"
-    )]
+    #[serde(default, skip_serializing_if = "String::is_empty")]
     pub block_trade_id: String,
     pub mark_price: String,
     pub exec_price: String,
-    #[serde( default, skip_serializing_if = "String::is_empty")]
-    pub mark_iv: String,  
-    pub order_qty: String, 
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub mark_iv: String,
+    pub order_qty: String,
     pub order_price: String,
     pub exec_value: String,
     pub exec_type: String,
@@ -1992,8 +1971,7 @@ impl<'a> BatchPlaceRequest<'a> {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct BatchPlaceResponse {
-    
-    pub ret_code: i16,
+    pub ret_code: i32,
     pub ret_msg: String,
     pub result: BatchedOrderList,
     pub ret_ext_info: OrderConfirmationList,
@@ -2044,7 +2022,7 @@ impl<'a> BatchAmendRequest<'a> {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct BatchAmendResponse {
-    pub ret_code: i16,
+    pub ret_code: i32,
     pub ret_msg: String,
     pub result: AmendedOrderList,
     pub ret_ext_info: OrderConfirmationList,
@@ -2083,8 +2061,8 @@ impl<'a> BatchCancelRequest<'a> {
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
-pub struct BatchCancelResponse{
-    pub ret_code: i16,
+pub struct BatchCancelResponse {
+    pub ret_code: i32,
     pub ret_msg: String,
     pub result: CanceledOrderList,
     pub ret_ext_info: OrderConfirmationList,
@@ -2160,7 +2138,7 @@ pub struct InfoResponse {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct InfoResult {
     pub list: Vec<PositionInfo>,
-    #[serde( skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub next_page_cursor: Option<String>,
     pub category: String,
 }
@@ -2721,7 +2699,7 @@ pub struct ClosedPnlItem {
     pub order_id: String,
     #[serde(with = "string_to_float")]
     pub closed_pnl: f64,
-    #[serde(rename = "avgEntryPrice", with = "string_to_float")]
+    #[serde(with = "string_to_float")]
     pub avg_entry_price: f64,
     pub qty: String,
     #[serde(with = "string_to_float")]
@@ -2730,7 +2708,7 @@ pub struct ClosedPnlItem {
     #[serde(with = "string_to_float")]
     pub order_price: f64,
     pub closed_size: String,
-    #[serde(rename = "avgExitPrice", with = "string_to_float")]
+    #[serde(with = "string_to_float")]
     pub avg_exit_price: f64,
     pub exec_type: String,
     pub fill_count: String,
@@ -2834,12 +2812,9 @@ impl<'a> MoveHistoryRequest<'a> {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct MoveHistoryResponse {
-    #[serde(rename = "retCode")]
-    pub ret_code: i16,
-    #[serde(rename = "retMsg")]
+    pub ret_code: i32,
     pub ret_msg: String,
     pub result: MoveHistoryResult,
-    #[serde(rename = "retExtInfo")]
     pub ret_ext_info: Empty,
     pub time: u64,
 }
@@ -2855,10 +2830,8 @@ pub struct MoveHistoryResult {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct MoveHistoryEntry {
-    #[serde(rename = "blockTradeId")]
     pub block_trade_id: String,
     pub category: String,
-    #[serde(rename = "orderId")]
     pub order_id: String,
     #[serde(rename = "userId")]
     pub user_id: u64,
@@ -2866,20 +2839,13 @@ pub struct MoveHistoryEntry {
     pub side: String,
     pub price: String,
     pub qty: String,
-    #[serde(rename = "execFee")]
     pub exec_fee: String,
     pub status: String,
-    #[serde(rename = "execId")]
     pub exec_id: String,
-    #[serde(rename = "resultCode")]
     pub result_code: i16,
-    #[serde(rename = "resultMessage")]
     pub result_message: String,
-    #[serde(rename = "createdAt")]
     pub created_at: u64,
-    #[serde(rename = "updatedAt")]
     pub updated_at: u64,
-    #[serde(rename = "rejectParty")]
     pub reject_party: String,
 }
 
@@ -2892,9 +2858,7 @@ pub struct MoveHistoryEntry {
 #[derive(Deserialize, Serialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct WalletResponse {
-    #[serde(rename = "retCode")]
     pub ret_code: i32,
-    #[serde(rename = "retMsg")]
     pub ret_msg: String,
     pub result: WalletList,
     #[serde(rename = "retExtInfo")]
@@ -2910,12 +2874,9 @@ pub struct WalletList {
 #[derive(Deserialize, Serialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct UTAResponse {
-    #[serde(rename = "retCode")]
     pub ret_code: i32,
-    #[serde(rename = "retMsg")]
     pub ret_msg: String,
     pub result: UTAUpdateStatus,
-    #[serde(rename = "retExtInfo")]
     pub ret_ext_info: Empty,
     pub time: u64,
 }
@@ -2923,9 +2884,7 @@ pub struct UTAResponse {
 #[derive(Deserialize, Serialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct UTAUpdateStatus {
-    #[serde(rename = "unifiedUpdateStatus")]
     pub unified_update_status: String,
-    #[serde(rename = "unifiedUpdateMsg")]
     pub unified_update_msg: UnifiedUpdateMsg,
 }
 
@@ -2981,22 +2940,14 @@ pub struct BorrowHistory {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct BorrowHistoryEntry {
-    #[serde(rename = "borrowAmount")]
     pub borrow_amount: String,
-    #[serde(rename = "costExemption")]
     pub cost_exemption: String,
-    #[serde(rename = "freeBorrowedAmount")]
     pub free_borrowed_amount: String,
-    #[serde(rename = "createdTime")]
     pub created_time: u64,
-    #[serde(rename = "InterestBearingBorrowSize")]
     pub interest_bearing_borrow_size: String,
     pub currency: String,
-    #[serde(rename = "unrealisedLoss")]
     pub unrealised_loss: String,
-    #[serde(rename = "hourlyBorrowRate")]
     pub hourly_borrow_rate: String,
-    #[serde(rename = "borrowCost")]
     pub borrow_cost: String,
 }
 
@@ -3074,30 +3025,18 @@ pub struct CollateralInfoList {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct CollateralInfo {
-    #[serde(rename = "availableToBorrow")]
     pub available_to_borrow: String,
-    #[serde(rename = "freeBorrowingAmount")]
     pub free_borrowing_amount: String,
-    #[serde(rename = "freeBorrowAmount")]
     pub free_borrow_amount: String,
-    #[serde(rename = "maxBorrowingAmount")]
     pub max_borrowing_amount: String,
-    #[serde(rename = "hourlyBorrowRate")]
     pub hourly_borrow_rate: String,
-    #[serde(rename = "borrowUsageRate")]
     pub borrow_usage_rate: String,
-    #[serde(rename = "collateralSwitch")]
     pub collateral_switch: bool,
-    #[serde(rename = "borrowAmount")]
     pub borrow_amount: String,
-    #[serde(rename = "borrowable")]
     pub borrowable: bool,
     pub currency: String,
-    #[serde(rename = "marginCollateral")]
     pub margin_collateral: bool,
-    #[serde(rename = "freeBorrowingLimit")]
     pub free_borrowing_limit: String,
-    #[serde(rename = "collateralRatio")]
     pub collateral_ratio: String,
 }
 
@@ -3203,7 +3142,6 @@ pub struct TransactionLogEntry {
     pub cash_flow: String,
     pub transaction_time: String,
     pub type_field: String,
-    #[serde(rename = "feeRate")]
     pub fee_rate: String,
     pub bonus_change: Option<String>,
     pub size: String,
@@ -3417,8 +3355,8 @@ unsafe impl Send for WsOrderBook {}
 unsafe impl Sync for WsOrderBook {}
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct TradeUpdate {
-    #[serde(rename = "topic")]
     pub topic: String,
     #[serde(rename = "type")]
     pub event_type: String,
@@ -3467,6 +3405,7 @@ unsafe impl Send for WsTicker {}
 unsafe impl Sync for WsTicker {}
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct LinearTickerData {
     pub symbol: String,
     #[serde(rename = "tickDirection")]
@@ -3495,7 +3434,6 @@ pub struct LinearTickerData {
     pub turnover_24h: String,
     #[serde(rename = "volume24h")]
     pub volume_24h: String,
-    #[serde(rename = "nextFundingTime")]
     pub next_funding_time: String,
     #[serde(rename = "fundingRate")]
     pub funding_rate: String,
@@ -3513,10 +3451,9 @@ unsafe impl Send for LinearTickerData {}
 unsafe impl Sync for LinearTickerData {}
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct SpotTickerData {
-    #[serde(rename = "symbol")]
     pub symbol: String,
-    #[serde(rename = "lastPrice")]
     pub last_price: String,
     #[serde(rename = "highPrice24h")]
     pub high_price_24h: String,
@@ -3530,7 +3467,6 @@ pub struct SpotTickerData {
     pub turnover_24h: String,
     #[serde(rename = "price24hPcnt")]
     pub price_24h_pcnt: String,
-    #[serde(rename = "usdIndexPrice")]
     pub usd_index_price: String,
 }
 
@@ -3538,6 +3474,7 @@ unsafe impl Send for SpotTickerData {}
 unsafe impl Sync for SpotTickerData {}
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct Liquidation {
     #[serde(rename = "topic")]
     pub topic: String,
@@ -3553,12 +3490,10 @@ unsafe impl Send for Liquidation {}
 unsafe impl Sync for Liquidation {}
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct LiquidationData {
-    #[serde(rename = "updatedTime")]
     pub updated_time: u64,
-    #[serde(rename = "symbol")]
     pub symbol: String,
-    #[serde(rename = "side")]
     pub side: String,
     #[serde(with = "string_to_float")]
     pub size: f64,
@@ -3601,10 +3536,10 @@ unsafe impl Send for KlineData {}
 unsafe impl Sync for KlineData {}
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct PositionEvent {
     pub id: String,
     pub topic: String,
-    #[serde(rename = "creationTime")]
     pub creation_time: u64,
     pub data: Vec<PositionData>,
 }
@@ -3613,64 +3548,47 @@ unsafe impl Send for PositionEvent {}
 unsafe impl Sync for PositionEvent {}
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct PositionData {
     #[serde(rename = "positionIdx")]
     pub position_idx: u8,
-    #[serde(rename = "tradeMode")]
     pub trade_mode: u8,
-    #[serde(rename = "riskId")]
     pub risk_id: u8,
-    #[serde(rename = "riskLimitValue")]
     pub risk_limit_value: String,
     pub symbol: String,
     pub side: String,
     pub size: String,
-    #[serde(rename = "entryPrice")]
     pub entry_price: String,
     pub leverage: String,
-    #[serde(rename = "positionValue")]
     pub position_value: String,
-    #[serde(rename = "positionBalance")]
     pub position_balance: String,
-    #[serde(rename = "markPrice")]
     pub mark_price: String,
     #[serde(rename = "positionIM")]
     pub position_im: String,
     #[serde(rename = "positionMM")]
     pub position_mm: String,
-    #[serde(rename = "takeProfit")]
     pub take_profit: String,
-    #[serde(rename = "stopLoss")]
     pub stop_loss: String,
-    #[serde(rename = "trailingStop")]
     pub trailing_stop: String,
     #[serde(rename = "unrealisedPnl")]
     pub unrealised_pnl: String,
     #[serde(rename = "cumRealisedPnl")]
     pub cum_realised_pnl: String,
-    #[serde(rename = "createdTime")]
     pub created_time: String,
-    #[serde(rename = "updatedTime")]
     pub updated_time: String,
     #[serde(rename = "tpslMode")]
     pub tpsl_mode: String,
-    #[serde(rename = "liqPrice")]
     pub liq_price: String,
-    #[serde(rename = "bustPrice")]
     pub bust_price: String,
     pub category: String,
-    #[serde(rename = "positionStatus")]
     pub position_status: String,
-    #[serde(rename = "adlRankIndicator")]
     pub adl_rank_indicator: u8,
-    #[serde(rename = "autoAddMargin")]
     pub auto_add_margin: u8,
     #[serde(rename = "leverageSysUpdatedTime")]
     pub leverage_sys_updated_time: String,
     #[serde(rename = "mmrSysUpdatedTime")]
     pub mmr_sys_updated_time: String,
     pub seq: u64,
-    #[serde(rename = "isReduceOnly")]
     pub is_reduce_only: bool,
 }
 
@@ -3678,14 +3596,11 @@ unsafe impl Send for PositionData {}
 unsafe impl Sync for PositionData {}
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct Execution {
-    #[serde(rename = "id")]
     pub id: String,
-    #[serde(rename = "topic")]
     pub topic: String,
-    #[serde(rename = "creationTime")]
     pub creation_time: u64,
-    #[serde(rename = "data")]
     pub data: Vec<ExecutionData>,
 }
 
@@ -3693,24 +3608,16 @@ unsafe impl Send for Execution {}
 unsafe impl Sync for Execution {}
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct ExecutionData {
-    #[serde(rename = "category")]
     pub category: String,
-    #[serde(rename = "symbol")]
     pub symbol: String,
-    #[serde(rename = "execFee")]
     pub exec_fee: String,
-    #[serde(rename = "execId")]
     pub exec_id: String,
-    #[serde(rename = "execPrice")]
     pub exec_price: String,
-    #[serde(rename = "execQty")]
     pub exec_qty: String,
-    #[serde(rename = "execType")]
     pub exec_type: String,
-    #[serde(rename = "execValue")]
     pub exec_value: String,
-    #[serde(rename = "isMaker")]
     pub is_maker: bool,
     #[serde(rename = "feeRate")]
     pub fee_rate: String,
@@ -3720,35 +3627,21 @@ pub struct ExecutionData {
     pub mark_iv: String,
     #[serde(rename = "blockTradeId")]
     pub block_trade_id: String,
-    #[serde(rename = "markPrice")]
     pub mark_price: String,
-    #[serde(rename = "indexPrice")]
     pub index_price: String,
-    #[serde(rename = "underlyingPrice")]
     pub underlying_price: String,
-    #[serde(rename = "leavesQty")]
     pub leaves_qty: String,
-    #[serde(rename = "orderId")]
     pub order_id: String,
-    #[serde(rename = "orderLinkId")]
     pub order_link_id: String,
-    #[serde(rename = "orderPrice")]
     pub order_price: String,
-    #[serde(rename = "orderQty")]
     pub order_qty: String,
-    #[serde(rename = "orderType")]
     pub order_type: String,
     #[serde(rename = "stopOrderType")]
     pub stop_order_type: String,
-    #[serde(rename = "side")]
     pub side: String,
-    #[serde(rename = "execTime")]
     pub exec_time: String,
-    #[serde(rename = "isLeverage")]
     pub is_leverage: String,
-    #[serde(rename = "closedSize")]
     pub closed_size: String,
-    #[serde(rename = "seq")]
     pub seq: u64,
 }
 
@@ -3756,9 +3649,9 @@ unsafe impl Send for ExecutionData {}
 unsafe impl Sync for ExecutionData {}
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct FastExecution {
     pub topic: String,
-    #[serde(rename = "creationTime")]
     pub creation_time: u64,
     pub data: Vec<FastExecData>,
 }
@@ -3767,21 +3660,16 @@ unsafe impl Send for FastExecution {}
 unsafe impl Sync for FastExecution {}
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct FastExecData {
     pub category: String,
     pub symbol: String,
-    #[serde(rename = "execId")]
     pub exec_id: String,
-    #[serde(rename = "execPrice")]
     pub exec_price: String,
-    #[serde(rename = "execQty")]
     pub exec_qty: String,
-    #[serde(rename = "orderId")]
     pub order_id: String,
-    #[serde(rename = "orderLinkId")]
     pub order_link_id: String,
     pub side: String,
-    #[serde(rename = "execTime")]
     pub exec_time: String,
     pub seq: u64,
 }
@@ -3790,60 +3678,39 @@ unsafe impl Send for FastExecData {}
 unsafe impl Sync for FastExecData {}
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct OrderData {
     pub symbol: String,
-    #[serde(rename = "orderId")]
     pub order_id: String,
     pub side: String,
-    #[serde(rename = "orderType")]
     pub order_type: String,
-    #[serde(rename = "cancelType")]
     pub cancel_type: String,
     pub price: String,
     pub qty: String,
-    #[serde(rename = "orderIv")]
     pub order_iv: String,
-    #[serde(rename = "timeInForce")]
     pub time_in_force: String,
-    #[serde(rename = "orderStatus")]
     pub order_status: String,
-    #[serde(rename = "orderLinkId")]
     pub order_link_id: String,
-    #[serde(rename = "lastPriceOnCreated")]
     pub last_price_on_created: String,
-    #[serde(rename = "reduceOnly")]
     pub reduce_only: bool,
-    #[serde(rename = "leavesQty")]
     pub leaves_qty: String,
-    #[serde(rename = "leavesValue")]
     pub leaves_value: String,
-    #[serde(rename = "cumExecQty")]
     pub cum_exec_qty: String,
-    #[serde(rename = "cumExecValue")]
     pub cum_exec_value: String,
-    #[serde(rename = "avgPrice")]
     pub avg_price: String,
-    #[serde(rename = "blockTradeId")]
     pub block_trade_id: String,
     #[serde(rename = "positionIdx")]
     pub position_idx: u8,
-    #[serde(rename = "cumExecFee")]
     pub cum_exec_fee: String,
-    #[serde(rename = "createdTime")]
     pub created_time: String,
-    #[serde(rename = "updatedTime")]
     pub updated_time: String,
-    #[serde(rename = "rejectReason")]
     pub reject_reason: String,
     #[serde(rename = "stopOrderType")]
     pub stop_order_type: String,
     #[serde(rename = "tpslMode")]
     pub tpsl_mode: String,
-    #[serde(rename = "triggerPrice")]
     pub trigger_price: String,
-    #[serde(rename = "takeProfit")]
     pub take_profit: String,
-    #[serde(rename = "stopLoss")]
     pub stop_loss: String,
     #[serde(rename = "tpTriggerBy")]
     pub tp_trigger_by: String,
@@ -3853,22 +3720,14 @@ pub struct OrderData {
     pub tp_limit_price: String,
     #[serde(rename = "slLimitPrice")]
     pub sl_limit_price: String,
-    #[serde(rename = "triggerDirection")]
     pub trigger_direction: u8,
-    #[serde(rename = "triggerBy")]
     pub trigger_by: String,
-    #[serde(rename = "closeOnTrigger")]
     pub close_on_trigger: bool,
     pub category: String,
-    #[serde(rename = "placeType")]
     pub place_type: String,
-    #[serde(rename = "smpType")]
     pub smp_type: String,
-    #[serde(rename = "smpGroup")]
     pub smp_group: u8,
-    #[serde(rename = "smpOrderId")]
     pub smp_order_id: String,
-    #[serde(rename = "feeCurrency")]
     pub fee_currency: String,
 }
 
@@ -3876,10 +3735,10 @@ unsafe impl Send for OrderData {}
 unsafe impl Sync for OrderData {}
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct OrderEvent {
     pub id: String,
     pub topic: String,
-    #[serde(rename = "creationTime")]
     pub creation_time: u64,
     pub data: Vec<OrderData>,
 }
@@ -3888,10 +3747,10 @@ unsafe impl Send for OrderEvent {}
 unsafe impl Sync for OrderEvent {}
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct WalletEvent {
     pub id: String,
     pub topic: String,
-    #[serde(rename = "creationTime")]
     pub creation_time: u64,
     pub data: Vec<WalletData>,
 }
@@ -3899,70 +3758,59 @@ unsafe impl Send for WalletEvent {}
 unsafe impl Sync for WalletEvent {}
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct WalletData {
     #[serde(rename = "accountIMRate")]
     pub account_im_rate: String,
     #[serde(rename = "accountMMRate")]
     pub account_mm_rate: String,
-    #[serde(rename = "totalEquity")]
-    pub total_equity: String,
-    #[serde(rename = "totalWalletBalance")]
-    pub total_wallet_balance: String,
-    #[serde(rename = "totalMarginBalance")]
-    pub total_margin_balance: String,
-    #[serde(rename = "totalAvailableBalance")]
-    pub total_available_balance: String,
+    #[serde(with = "string_to_float")]
+    pub total_equity: f64,
+    #[serde(with = "string_to_float")]
+    pub total_wallet_balance: f64,
+    #[serde(with = "string_to_float")]
+    pub total_margin_balance: f64,
+    #[serde(with = "string_to_float")]
+    pub total_available_balance: f64,
     #[serde(rename = "totalPerpUPL")]
     pub total_perp_upl: String,
-    #[serde(rename = "totalInitialMargin")]
     pub total_initial_margin: String,
-    #[serde(rename = "totalMaintenanceMargin")]
     pub total_maintenance_margin: String,
-    #[serde(rename = "coin")]
     pub coin: Vec<CoinData>,
     #[serde(rename = "accountLTV")]
     pub account_ltv: String,
-    #[serde(rename = "accountType", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub account_type: Option<String>,
 }
 unsafe impl Send for WalletData {}
 unsafe impl Sync for WalletData {}
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct CoinData {
-    #[serde(rename = "coin")]
     pub coin: String,
-    #[serde(rename = "equity")]
     pub equity: String,
-    #[serde(rename = "usdValue")]
     pub usd_value: String,
-    #[serde(rename = "walletBalance")]
     pub wallet_balance: String,
-    #[serde(rename = "availableToWithdraw")]
     pub available_to_withdraw: String,
-    #[serde(rename = "availableToBorrow")]
     pub available_to_borrow: String,
-    #[serde(rename = "borrowAmount")]
-    pub borrow_amount: String,
-    #[serde(rename = "accruedInterest")]
-    pub accrued_interest: String,
+    #[serde(with = "string_to_float")]
+    pub borrow_amount: f64,
+    #[serde(with = "string_to_float")]
+    pub accrued_interest: f64,
     #[serde(rename = "totalOrderIM")]
     pub total_order_im: String,
     #[serde(rename = "totalPositionIM")]
     pub total_position_im: String,
     #[serde(rename = "totalPositionMM")]
     pub total_position_mm: String,
-    #[serde(rename = "unrealisedPnl")]
-    pub unrealised_pnl: String,
-    #[serde(rename = "cumRealisedPnl")]
-    pub cum_realised_pnl: String,
+    #[serde(with = "string_to_float")]
+    pub unrealised_pnl: f64,
+    #[serde(with = "string_to_float")]
+    pub cum_realised_pnl: f64,
     pub bonus: String,
-    #[serde(rename = "collateralSwitch")]
     pub collateral_switch: bool,
-    #[serde(rename = "marginCollateral")]
     pub margin_collateral: bool,
-    #[serde(rename = "locked")]
     pub locked: String,
-    #[serde(rename = "spotHedgingQty")]
     pub spot_hedging_qty: String,
 }
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -266,15 +266,6 @@ pub struct FuturesInstrument {
     // pub pre_listing_info: PreListingInfo,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
-#[serde(rename_all = "camelCase")]
-pub struct SpotInstrumentsInfoResponse {
-    pub ret_code: i16,
-    pub ret_msg: String,
-    pub result: SpotInstrumentsInfo,
-    pub ret_ext_info: Empty,
-    pub time: u64,
-}
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
@@ -331,9 +322,9 @@ pub struct PreListingInfo {
 #[serde(rename_all = "camelCase")]
 pub struct PreListingPhase {
     pub phase: String,
-    #[serde(rename = "startTime", with = "string_to_u64")]
+    #[serde(with = "string_to_u64")]
     pub start_time: u64,
-    #[serde(rename = "endTime", with = "string_to_u64")]
+    #[serde(with = "string_to_u64")]
     pub end_time: u64,
 }
 
@@ -348,63 +339,53 @@ pub struct AuctionFeeInfo {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct RiskParameters {
-    #[serde(rename = "limitParameter")]
     pub limit_parameter: String,
-    #[serde(rename = "marketParameter")]
     pub market_parameter: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct LeverageFilter {
-    #[serde(rename = "minLeverage")]
     pub min_leverage: String,
-    #[serde(rename = "maxLeverage")]
     pub max_leverage: String,
-    #[serde(rename = "leverageStep")]
     pub leverage_step: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct PriceFilter {
-    #[serde(rename = "minPrice")]
+    #[serde(skip_serializing_if = "is_empty_or_none")]
     pub min_price: Option<String>,
-    #[serde(rename = "maxPrice")]
+    #[serde(skip_serializing_if = "is_empty_or_none")]
     pub max_price: Option<String>,
-    #[serde(rename = "tickSize", with = "string_to_float")]
+    #[serde(with = "string_to_float")]
     pub tick_size: f64,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct LotSizeFilter {
-    #[serde(
-        rename = "basePrecision",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(skip_serializing_if = "is_empty_or_none")]
     pub base_precision: Option<String>,
-    #[serde(rename = "quotePrecision", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub quote_precision: Option<String>,
-    #[serde(rename = "maxMktOrderQty", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub max_mkt_order_qty: Option<String>,
-    #[serde(rename = "minOrderQty", with = "string_to_float")]
+    #[serde(with = "string_to_float")]
     pub min_order_qty: f64,
-    #[serde(rename = "maxOrderQty", with = "string_to_float")]
+    #[serde(with = "string_to_float")]
     pub max_order_qty: f64,
-    #[serde(rename = "minOrderAmt", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub min_order_amt: Option<String>,
-    #[serde(rename = "maxOrderAmt", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub max_order_amt: Option<String>,
-    #[serde(rename = "qtyStep", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub qty_step: Option<String>,
     #[serde(
-        rename = "postOnlyMaxOrderQty",
         skip_serializing_if = "Option::is_none"
     )]
     pub post_only_max_order_qty: Option<String>,
-    #[serde(rename = "minNotionalValue", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub min_notional_value: Option<String>,
 }
 
@@ -431,18 +412,14 @@ impl<'a> OrderbookRequest<'a> {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct OrderBookResponse {
-    #[serde(rename = "retCode")]
     pub ret_code: i16,
-    #[serde(rename = "retMsg")]
     pub ret_msg: String,
     pub result: OrderBook,
-    #[serde(rename = "retExtInfo")]
     pub ret_ext_info: Empty,
     pub time: u64,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
-#[serde(rename_all = "camelCase")]
 pub struct OrderBook {
     #[serde(rename = "s")]
     pub symbol: String,
@@ -485,43 +462,30 @@ impl Ask {
     }
 }
 
+
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
-pub struct FuturesTickersResponse {
-    #[serde(rename = "retCode")]
+pub struct TickerResponse {
     pub ret_code: i16,
-    #[serde(rename = "retMsg")]
     pub ret_msg: String,
-    pub result: FuturesTickers,
-    #[serde(rename = "retExtInfo")]
-    pub ret_ext_info: Empty,
-    pub time: u64,
-}
-#[derive(Serialize, Deserialize, Clone, Debug)]
-#[serde(rename_all = "camelCase")]
-pub struct SpotTickersResponse {
-    #[serde(rename = "retCode")]
-    pub ret_code: i16,
-    #[serde(rename = "retMsg")]
-    pub ret_msg: String,
-    pub result: SpotTickers,
-    #[serde(rename = "retExtInfo")]
+    pub result: TickersInfo,
     pub ret_ext_info: Empty,
     pub time: u64,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
-pub struct FuturesTickers {
+pub struct TickersInfo {
     pub category: String,
-    pub list: Vec<FuturesTicker>,
+    pub list: Vec<TickerData>,
 }
 
+
 #[derive(Serialize, Deserialize, Clone, Debug)]
-#[serde(rename_all = "camelCase")]
-pub struct SpotTickers {
-    pub category: String,
-    pub list: Vec<SpotTicker>,
+#[serde(untagged)]
+pub enum TickerData {
+    Spot(SpotTicker),
+    Futures(FuturesTicker),
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -534,7 +498,7 @@ pub struct FuturesTicker {
     pub index_price: f64,
     #[serde(with = "string_to_float")]
     pub mark_price: f64,
-    #[serde(rename = "prevPrice24h", with = "string_to_float")]
+    #[serde(with = "string_to_float")]
     pub prev_price_24h: f64,
     #[serde(rename = "price24hPcnt", with = "string_to_float")]
     pub daily_change_percentage: f64,
@@ -542,25 +506,25 @@ pub struct FuturesTicker {
     pub high_24h: f64,
     #[serde(rename = "lowPrice24h", with = "string_to_float")]
     pub low_24h: f64,
-    #[serde(rename = "prevPrice1h", with = "string_to_float")]
+    #[serde(with = "string_to_float")]
     pub prev_price_1h: f64,
     #[serde(with = "string_to_float")]
     pub open_interest: f64,
     #[serde(with = "string_to_float")]
     pub open_interest_value: f64,
-    #[serde(rename = "turnover24h")]
-    pub turnover_24h: String,
-    #[serde(rename = "volume24h")]
-    pub volume_24h: String,
+    #[serde(with = "string_to_float")]
+    pub turnover_24h: f64,
+    #[serde(with = "string_to_float")]
+    pub volume_24h: f64,
     pub funding_rate: String,
-    #[serde(rename = "nextFundingTime", with = "string_to_u64")]
+    #[serde(with = "string_to_u64")]
     pub next_funding_time: u64,
     #[serde(skip_serializing_if = "String::is_empty")]
     pub predicted_delivery_price: String,
     #[serde(skip_serializing_if = "String::is_empty")]
     pub basis_rate: String,
     pub delivery_fee_rate: String,
-    #[serde(rename = "deliveryTime", with = "string_to_u64")]
+    #[serde(with = "string_to_u64")]
     pub delivery_time: u64,
     #[serde(rename = "ask1Size", with = "string_to_float")]
     pub ask_size: f64,
@@ -596,12 +560,12 @@ pub struct SpotTicker {
     pub high_24h: f64,
     #[serde(rename = "lowPrice24h", with = "string_to_float")]
     pub low_24h: f64,
-    #[serde(rename = "turnover24h")]
-    pub turnover_24h: String,
-    #[serde(rename = "volume24h")]
-    pub volume_24h: String,
-    #[serde(rename = "usdIndexPrice")]
-    pub usd_index_price: String,
+    #[serde(with = "string_to_float")]
+    pub turnover_24h: f64,
+    #[serde(with = "string_to_float")]
+    pub volume_24h: f64,
+    #[serde(with = "string_to_float")]
+    pub usd_index_price: f64,
 }
 
 #[derive(Clone, Default)]
@@ -636,12 +600,9 @@ impl<'a> FundingHistoryRequest<'a> {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct FundingRateResponse {
-    #[serde(rename = "retCode")]
     pub ret_code: i16,
-    #[serde(rename = "retMsg")]
     pub ret_msg: String,
     pub result: FundingRateSummary,
-    #[serde(rename = "retExtInfo")]
     pub ret_ext_info: Empty,
     pub time: u64,
 }
@@ -657,9 +618,9 @@ pub struct FundingRateSummary {
 #[serde(rename_all = "camelCase")]
 pub struct FundingRate {
     pub symbol: String,
-    #[serde(rename = "fundingRate", with = "string_to_float")]
+    #[serde(with = "string_to_float")]
     pub funding_rate: f64,
-    #[serde(rename = "fundingRateTimestamp", with = "string_to_u64")]
+    #[serde(with = "string_to_u64")]
     pub funding_rate_timestamp: u64,
 }
 
@@ -692,12 +653,9 @@ impl<'a> RecentTradesRequest<'a> {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct RecentTradesResponse {
-    #[serde(rename = "retCode")]
     pub ret_code: i16,
-    #[serde(rename = "retMsg")]
     pub ret_msg: String,
     pub result: RecentTrades,
-    #[serde(rename = "retExtInfo")]
     pub ret_ext_info: Empty,
     pub time: u64,
 }
@@ -712,7 +670,6 @@ pub struct RecentTrades {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct RecentTrade {
-    #[serde(rename = "execId")]
     pub exec_id: String,
     pub symbol: String,
     #[serde(with = "string_to_float")]
@@ -720,9 +677,8 @@ pub struct RecentTrade {
     #[serde(rename = "size", with = "string_to_float")]
     pub qty: f64,
     pub side: String,
-    #[serde(rename = "time")]
-    pub timestamp: String,
-    #[serde(rename = "isBlockTrade")]
+    #[serde(rename = "time", with = "string_to_u64")]
+    pub timestamp: u64,
     pub is_block_trade: bool,
 }
 
@@ -761,12 +717,9 @@ impl<'a> OpenInterestRequest<'a> {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct OpeninterestResponse {
-    #[serde(rename = "retCode")]
     pub ret_code: i16,
-    #[serde(rename = "retMsg")]
     pub ret_msg: String,
     pub result: OpenInterestSummary,
-    #[serde(rename = "retExtInfo")]
     pub ret_ext_info: Empty,
     pub time: u64,
 }
@@ -777,14 +730,14 @@ pub struct OpenInterestSummary {
     pub symbol: String,
     pub category: String,
     pub list: Vec<OpenInterest>,
-    #[serde(rename = "nextPageCursor", skip_serializing_if = "String::is_empty")]
+    #[serde(skip_serializing_if = "String::is_empty")]
     pub next_page_cursor: String,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct OpenInterest {
-    #[serde(rename = "openInterest", with = "string_to_float")]
+    #[serde(with = "string_to_float")]
     pub open_interest: f64,
     #[serde(with = "string_to_u64")]
     pub timestamp: u64,
@@ -820,12 +773,9 @@ impl<'a> HistoricalVolatilityRequest<'a> {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct HistoricalVolatilityResponse {
-    #[serde(rename = "retCode")]
     pub ret_code: i16,
-    #[serde(rename = "retMsg")]
     pub ret_msg: String,
     pub category: String,
-    #[serde(rename = "result")]
     pub result: Vec<HistoricalVolatility>,
 }
 
@@ -842,12 +792,9 @@ pub struct HistoricalVolatility {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct InsuranceResponse {
-    #[serde(rename = "retCode")]
     pub ret_code: i16,
-    #[serde(rename = "retMsg")]
     pub ret_msg: String,
     pub result: InsuranceSummary,
-    #[serde(rename = "retExtInfo")]
     pub ret_ext_info: Empty,
     pub time: u64,
 }
@@ -855,7 +802,7 @@ pub struct InsuranceResponse {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct InsuranceSummary {
-    #[serde(rename = "updatedTime", with = "string_to_u64")]
+    #[serde(with = "string_to_u64")]
     pub updated_time: u64,
     pub list: Vec<Insurance>,
 }
@@ -889,12 +836,9 @@ impl<'a> RiskLimitRequest<'a> {
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct RiskLimitResponse {
-    #[serde(rename = "retCode")]
     pub ret_code: i16,
-    #[serde(rename = "retMsg")]
     pub ret_msg: String,
     pub result: RiskLimitSummary,
-    #[serde(rename = "retExtInfo")]
     pub ret_ext_info: Empty,
     pub time: u64,
 }
@@ -909,15 +853,13 @@ pub struct RiskLimitSummary {
 pub struct RiskLimit {
     pub id: u64,
     pub symbol: String,
-    #[serde(rename = "riskLimitValue", with = "string_to_float")]
+    #[serde( with = "string_to_float")]
     pub risk_limit_value: f64,
-    #[serde(rename = "maintenanceMargin", with = "string_to_float")]
+    #[serde(with = "string_to_float")]
     pub maintainence_margin: f64,
-    #[serde(rename = "initialMargin", with = "string_to_float")]
+    #[serde(with = "string_to_float")]
     pub initial_margin: f64,
-    #[serde(rename = "isLowestRisk")]
     pub is_lowest_risk: u8,
-    #[serde(rename = "maxLeverage")]
     pub max_leverage: String,
 }
 
@@ -935,7 +877,7 @@ pub struct DeliveryPriceResponse {
 #[serde(rename_all = "camelCase")]
 pub struct DeliveryPriceSummary {
     pub category: String,
-    #[serde(rename = "nextPageCursor", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub next_page_cursor: Option<String>,
     pub list: Vec<DeliveryPrice>,
 }
@@ -952,12 +894,9 @@ pub struct DeliveryPrice {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct LongShortRatioResponse {
-    #[serde(rename = "retCode")]
     pub ret_code: i16,
-    #[serde(rename = "retMsg")]
     pub ret_msg: String,
     pub result: LongShortRatioSummary,
-    #[serde(rename = "retExtInfo")]
     pub ret_ext_info: Empty,
     pub time: u64,
 }
@@ -971,13 +910,12 @@ pub struct LongShortRatioSummary {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct LongShortRatio {
-    #[serde(rename = "symbol")]
     pub symbol: String,
-    #[serde(rename = "buyRatio", with = "string_to_float")]
+    #[serde(with = "string_to_float")]
     pub buy_ratio: f64,
-    #[serde(rename = "sellRatio", with = "string_to_float")]
+    #[serde(with = "string_to_float")]
     pub sell_ratio: f64,
-    #[serde(rename = "timestamp", with = "string_to_u64")]
+    #[serde(with = "string_to_u64")]
     pub timestamp: u64,
 }
 
@@ -1569,21 +1507,16 @@ pub struct OpenOrdersResponse {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct OrderStatus {
-    #[serde(rename = "orderId")]
     pub order_id: String,
-    #[serde(rename = "orderLinkId")]
     pub order_link_id: String,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct OrderResponse {
-    #[serde(rename = "retCode")]
     pub ret_code: i16,
-    #[serde(rename = "retMsg")]
     pub ret_msg: String,
     pub result: OrderStatus,
-    #[serde(rename = "retExtInfo")]
     pub ret_ext_info: Empty,
     pub time: u64,
 }
@@ -1651,9 +1584,7 @@ impl<'a> OrderHistoryRequest<'a> {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct OrderHistoryResponse {
-    #[serde(rename = "retCode")]
     pub ret_code: i16,
-    #[serde(rename = "retMsg")]
     pub ret_msg: String,
     pub result: OrderHistory,
     #[serde(rename = "retExtInfo")]
@@ -1666,7 +1597,7 @@ pub struct OrderHistoryResponse {
 pub struct OrderHistory {
     pub category: String,
     pub list: Vec<Order>,
-    #[serde(rename = "nextPageCursor", skip_serializing_if = "String::is_empty")]
+    #[serde( skip_serializing_if = "String::is_empty")]
     pub next_page_cursor: String,
 }
 
@@ -1903,12 +1834,12 @@ impl<'a> CancelallRequest<'a> {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct CancelallResponse {
-    #[serde(rename = "retCode")]
+    
     pub ret_code: i16,
-    #[serde(rename = "retMsg")]
+    
     pub ret_msg: String,
     pub result: CancelledList,
-    #[serde(rename = "retExtInfo")]
+    
     pub ret_ext_info: Empty,
     pub time: u64,
 }
@@ -1932,7 +1863,7 @@ pub struct TradeHistoryResponse {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct TradeHistorySummary {
-    #[serde(rename = "nextPageCursor", skip_serializing_if = "String::is_empty")]
+    #[serde( skip_serializing_if = "String::is_empty")]
     pub next_page_cursor: String,
     pub category: String,
     pub list: Vec<TradeHistory>,
@@ -1941,72 +1872,51 @@ pub struct TradeHistorySummary {
 #[serde(rename_all = "camelCase")]
 pub struct TradeHistory {
     pub symbol: String,
-    #[serde(rename = "orderType")]
     pub order_type: String,
     #[serde(
-        rename = "underlyingPrice",
         default,
         skip_serializing_if = "String::is_empty"
     )]
     pub underlying_price: String,
     #[serde(
-        rename = "orderLinkId",
         default,
         skip_serializing_if = "String::is_empty"
     )]
     pub order_link_id: String,
     pub side: String,
     #[serde(
-        rename = "indexPrice",
         default,
         skip_serializing_if = "String::is_empty"
     )]
     pub index_price: String,
-    #[serde(rename = "orderId")]
     pub order_id: String,
-    #[serde(rename = "stopOrderType")]
     pub stop_order_type: String,
-    #[serde(rename = "leavesQty")]
     pub leaves_qty: String,
-    #[serde(rename = "execTime")]
     pub exec_time: String,
     #[serde(
-        rename = "feeCurrency",
         default,
         skip_serializing_if = "String::is_empty"
     )]
     pub fee_currency: String,
-    #[serde(rename = "isMaker")]
     pub is_maker: bool,
-    #[serde(rename = "execFee")]
     pub exec_fee: String,
-    #[serde(rename = "feeRate")]
     pub fee_rate: String,
-    #[serde(rename = "execId")]
     pub exec_id: String,
-    #[serde(rename = "tradeIv", default, skip_serializing_if = "String::is_empty")]
+    #[serde( default, skip_serializing_if = "String::is_empty")]
     pub trade_iv: String,
     #[serde(
-        rename = "blockTradeId",
         default,
         skip_serializing_if = "String::is_empty"
     )]
     pub block_trade_id: String,
-    #[serde(rename = "markPrice")]
     pub mark_price: String,
-    #[serde(rename = "execPrice")]
     pub exec_price: String,
-    #[serde(rename = "markIv", default, skip_serializing_if = "String::is_empty")]
-    pub mark_iv: String,
-    #[serde(rename = "orderQty")]
-    pub order_qty: String,
-    #[serde(rename = "orderPrice")]
+    #[serde( default, skip_serializing_if = "String::is_empty")]
+    pub mark_iv: String,  
+    pub order_qty: String, 
     pub order_price: String,
-    #[serde(rename = "execValue")]
     pub exec_value: String,
-    #[serde(rename = "execType")]
     pub exec_type: String,
-    #[serde(rename = "execQty")]
     pub exec_qty: String,
     #[serde(
         rename = "closedSize",

--- a/src/model.rs
+++ b/src/model.rs
@@ -1992,12 +1992,10 @@ impl<'a> BatchPlaceRequest<'a> {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct BatchPlaceResponse {
-    #[serde(rename = "retCode")]
+    
     pub ret_code: i16,
-    #[serde(rename = "retMsg")]
     pub ret_msg: String,
     pub result: BatchedOrderList,
-    #[serde(rename = "retExtInfo")]
     pub ret_ext_info: OrderConfirmationList,
     pub time: u64,
 }
@@ -2013,11 +2011,8 @@ pub struct BatchedOrderList {
 pub struct BatchedOrder {
     pub category: String,
     pub symbol: String,
-    #[serde(rename = "orderId")]
     pub order_id: String,
-    #[serde(rename = "orderLinkId")]
     pub order_link_id: String,
-    #[serde(rename = "createAt")]
     pub create_at: String,
 }
 
@@ -2049,12 +2044,9 @@ impl<'a> BatchAmendRequest<'a> {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct BatchAmendResponse {
-    #[serde(rename = "retCode")]
     pub ret_code: i16,
-    #[serde(rename = "retMsg")]
     pub ret_msg: String,
     pub result: AmendedOrderList,
-    #[serde(rename = "retExtInfo")]
     pub ret_ext_info: OrderConfirmationList,
     pub time: u64,
 }
@@ -2070,9 +2062,7 @@ pub struct AmendedOrderList {
 pub struct AmendedOrder {
     pub category: String,
     pub symbol: String,
-    #[serde(rename = "orderId")]
     pub order_id: String,
-    #[serde(rename = "orderLinkId")]
     pub order_link_id: String,
 }
 
@@ -2093,13 +2083,10 @@ impl<'a> BatchCancelRequest<'a> {
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
-pub struct BatchCancelResponse {
-    #[serde(rename = "retCode")]
+pub struct BatchCancelResponse{
     pub ret_code: i16,
-    #[serde(rename = "retMsg")]
     pub ret_msg: String,
     pub result: CanceledOrderList,
-    #[serde(rename = "retExtInfo")]
     pub ret_ext_info: OrderConfirmationList,
     pub time: u64,
 }
@@ -2115,9 +2102,7 @@ pub struct CanceledOrderList {
 pub struct CanceledOrder {
     pub category: String,
     pub symbol: String,
-    #[serde(rename = "orderId")]
     pub order_id: String,
-    #[serde(rename = "orderLinkId")]
     pub order_link_id: String,
 }
 
@@ -2175,7 +2160,7 @@ pub struct InfoResponse {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct InfoResult {
     pub list: Vec<PositionInfo>,
-    #[serde(rename = "nextPageCursor", skip_serializing_if = "Option::is_none")]
+    #[serde( skip_serializing_if = "Option::is_none")]
     pub next_page_cursor: Option<String>,
     pub category: String,
 }
@@ -2241,80 +2226,50 @@ mod string_to_float_optional {
 #[serde(rename_all = "camelCase")]
 pub struct PositionInfo {
     pub position_idx: i32,
-
     pub risk_id: i32,
-
     #[serde(with = "string_to_float")]
     pub risk_limit_value: f64,
-
     pub symbol: String,
-
     pub side: String,
-
     #[serde(with = "string_to_float")]
     pub size: f64,
-
     #[serde(with = "string_to_float_optional")]
     pub avg_price: Option<f64>,
-
     #[serde(with = "string_to_float_optional")]
     pub position_value: Option<f64>,
-
     pub trade_mode: i32,
-
     pub position_status: String,
-
     pub auto_add_margin: i32,
-
     pub adl_rank_indicator: i32,
-
     #[serde(with = "string_to_float_optional")]
     pub leverage: Option<f64>,
-
     #[serde(with = "string_to_float")]
     pub position_balance: f64,
-
     #[serde(with = "string_to_float")]
     pub mark_price: f64,
-
     #[serde(with = "string_to_float_optional")]
     pub liq_price: Option<f64>,
-
     pub bust_price: String,
-
     #[serde(rename = "positionMM", with = "string_to_float_optional")]
     pub position_mm: Option<f64>,
-
     #[serde(rename = "positionIM", with = "string_to_float_optional")]
     pub position_im: Option<f64>,
-
     pub tpsl_mode: String,
-
     pub take_profit: String,
-
     pub stop_loss: String,
-
     pub trailing_stop: String,
-
     #[serde(with = "string_to_float_optional")]
     pub unrealised_pnl: Option<f64>,
-
     #[serde(with = "string_to_float_optional")]
     pub cum_realised_pnl: Option<f64>,
-
     pub seq: u64,
-
     pub is_reduce_only: bool,
-
     #[serde(with = "string_to_u64_optional")]
     pub mmr_sys_updated_time: Option<u64>,
-
     #[serde(with = "string_to_u64_optional")]
     pub leverage_sys_updated_time: Option<u64>,
-
     #[serde(with = "string_to_u64")]
     pub created_time: u64,
-
     #[serde(with = "string_to_u64")]
     pub updated_time: u64,
 }
@@ -2394,12 +2349,9 @@ impl<'a> LeverageRequest<'a> {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct LeverageResponse {
-    #[serde(rename = "retCode")]
     pub ret_code: i32,
-    #[serde(rename = "retMsg")]
     pub ret_msg: String,
     pub result: Empty, // Assuming result is an empty struct as per provided JSON
-    #[serde(rename = "retExtInfo")]
     pub ret_ext_info: Empty, // Assuming retExtInfo is an empty struct as per provided JSON
     pub time: u64,
 }
@@ -2433,12 +2385,9 @@ impl<'a> ChangeMarginRequest<'a> {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct ChangeMarginResponse {
-    #[serde(rename = "retCode")]
     pub ret_code: i32,
-    #[serde(rename = "retMsg")]
     pub ret_msg: String,
     pub result: Empty, // Assuming result is an empty struct as per provided JSON
-    #[serde(rename = "retExtInfo")]
     pub ret_ext_info: Empty, // Assuming retExtInfo is an empty struct as per provided JSON
     pub time: u64,
 }
@@ -2473,12 +2422,9 @@ impl<'a> MarginModeRequest<'a> {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct MarginModeResponse {
-    #[serde(rename = "retCode")]
     pub ret_code: i32,
-    #[serde(rename = "retMsg")]
     pub ret_msg: String,
     pub result: Empty, // Assuming result is an empty struct as per provided JSON
-    #[serde(rename = "retExtInfo")]
     pub ret_ext_info: Empty, // Assuming retExtInfo is an empty struct as per provided JSON
     pub time: u64,
 }
@@ -2513,21 +2459,17 @@ impl<'a> SetRiskLimit<'a> {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct SetRiskLimitResponse {
-    #[serde(rename = "retCode")]
     pub ret_code: i32,
-    #[serde(rename = "retMsg")]
     pub ret_msg: String,
     pub result: SetRiskLimitResult,
-    #[serde(rename = "retExtInfo")]
     pub ret_ext_info: Empty, // Assuming retExtInfo is a JSON value as per provided JSON
     pub time: u64,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct SetRiskLimitResult {
-    #[serde(rename = "riskId")]
     pub risk_id: i32,
-    #[serde(rename = "riskLimitValue", with = "string_to_u64")]
+    #[serde(with = "string_to_u64")]
     pub risk_limit_value: u64,
     pub category: String,
 }
@@ -2608,12 +2550,9 @@ impl<'a> TradingStopRequest<'a> {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct TradingStopResponse {
-    #[serde(rename = "retCode")]
     pub ret_code: i32,
-    #[serde(rename = "retMsg")]
     pub ret_msg: String,
     pub result: Empty, // Assuming result is an empty struct as per provided JSON
-    #[serde(rename = "retExtInfo")]
     pub ret_ext_info: Empty, // Assuming retExtInfo is an empty struct as per provided JSON
     pub time: u64,
 }
@@ -2648,12 +2587,9 @@ impl<'a> AddMarginRequest<'a> {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct AddMarginResponse {
-    #[serde(rename = "retCode")]
     pub ret_code: i32,
-    #[serde(rename = "retMsg")]
     pub ret_msg: String,
     pub result: Empty, // Assuming result is an empty struct as per provided JSON
-    #[serde(rename = "retExtInfo")]
     pub ret_ext_info: Empty, // Assuming retExtInfo is an empty struct as per provided JSON
     pub time: u64,
 }
@@ -2688,12 +2624,9 @@ impl<'a> AddReduceMarginRequest<'a> {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct AddReduceMarginResponse {
-    #[serde(rename = "retCode")]
     pub ret_code: i32,
-    #[serde(rename = "retMsg")]
     pub ret_msg: String,
     pub result: AddReduceMarginResult,
-    #[serde(rename = "retExtInfo")]
     pub ret_ext_info: Empty, // Assuming retExtInfo is an empty struct as per provided JSON
     pub time: u64,
 }
@@ -2704,43 +2637,27 @@ pub struct AddReduceMarginResult {
     pub category: String,
     pub symbol: String,
     pub position_idx: i32,
-    #[serde(rename = "riskId")]
     pub risk_id: i32,
-    #[serde(rename = "riskLimitValue")]
     pub risk_limit_value: String,
     pub size: String,
-    #[serde(rename = "positionValue")]
     pub position_value: String,
-    #[serde(rename = "avgPrice")]
     pub avg_price: String,
-    #[serde(rename = "liqPrice")]
     pub liq_price: String,
-    #[serde(rename = "bustPrice")]
     pub bust_price: String,
-    #[serde(rename = "markPrice")]
     pub mark_price: String,
     pub leverage: String,
-    #[serde(rename = "autoAddMargin")]
     pub auto_add_margin: i32,
-    #[serde(rename = "positionStatus")]
     pub position_status: String,
     #[serde(rename = "positionIM")]
     pub position_im: String,
     #[serde(rename = "positionMM")]
     pub position_mm: String,
-    #[serde(rename = "unrealisedPnl")]
     pub unrealised_pnl: String,
-    #[serde(rename = "cumRealisedPnl")]
     pub cum_realised_pnl: String,
-    #[serde(rename = "stopLoss")]
     pub stop_loss: String,
-    #[serde(rename = "takeProfit")]
     pub take_profit: String,
-    #[serde(rename = "trailingStop")]
     pub trailing_stop: String,
-    #[serde(rename = "createdTime")]
     pub created_time: String,
-    #[serde(rename = "updatedTime")]
     pub updated_time: String,
 }
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -66,12 +66,9 @@ impl<'a> KlineRequest<'a> {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct KlineResponse {
-    #[serde(rename = "retCode")]
     pub ret_code: i16,
-    #[serde(rename = "retMsg")]
     pub ret_msg: String,
     pub result: KlineSummary,
-    #[serde(rename = "retExtInfo")]
     pub ret_ext_info: Empty,
     pub time: u64,
 }
@@ -100,12 +97,9 @@ pub struct Kline {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct MarkPriceKlineResponse {
-    #[serde(rename = "retCode")]
     pub ret_code: i16,
-    #[serde(rename = "retMsg")]
     pub ret_msg: String,
     pub result: MarkPriceKlineSummary,
-    #[serde(rename = "retExtInfo")]
     pub ret_ext_info: Empty,
     pub time: u64,
 }
@@ -132,12 +126,9 @@ pub struct MarkPriceKline {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct IndexPriceKlineResponse {
-    #[serde(rename = "retCode")]
     pub ret_code: i16,
-    #[serde(rename = "retMsg")]
     pub ret_msg: String,
     pub result: IndexPriceKlineSummary,
-    #[serde(rename = "retExtInfo")]
     pub ret_ext_info: Empty,
     pub time: u64,
 }
@@ -164,12 +155,9 @@ pub struct IndexPriceKline {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct PremiumIndexPriceKlineResponse {
-    #[serde(rename = "retCode")]
     pub ret_code: i16,
-    #[serde(rename = "retMsg")]
     pub ret_msg: String,
     pub result: PremiumIndexPriceKlineSummary,
-    #[serde(rename = "retExtInfo")]
     pub ret_ext_info: Empty,
     pub time: u64,
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -212,15 +212,20 @@ impl<'a> InstrumentRequest<'a> {
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
-pub struct FuturesInstrumentsInfoResponse {
-    #[serde(rename = "retCode")]
+pub struct InstrumentInfoResponse {
     pub ret_code: i16,
-    #[serde(rename = "retMsg")]
     pub ret_msg: String,
-    pub result: FuturesInstrumentsInfo,
-    #[serde(rename = "retExtInfo")]
+    pub result: InstrumentInfo,
     pub ret_ext_info: Empty,
     pub time: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(untagged)]
+pub enum InstrumentInfo {
+    Futures(FuturesInstrumentsInfo),
+    Spot(SpotInstrumentsInfo),
+    Options(OptionsInstrument),
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -228,7 +233,7 @@ pub struct FuturesInstrumentsInfoResponse {
 pub struct FuturesInstrumentsInfo {
     pub category: String,
     pub list: Vec<FuturesInstrument>,
-    #[serde(rename = "nextPageCursor", skip_serializing_if = "String::is_empty")]
+    #[serde(skip_serializing_if = "String::is_empty")]
     pub next_page_cursor: String,
 }
 
@@ -236,38 +241,24 @@ pub struct FuturesInstrumentsInfo {
 #[serde(rename_all = "camelCase")]
 pub struct FuturesInstrument {
     pub symbol: String,
-    #[serde(rename = "contractType")]
     pub contract_type: String,
     pub status: String,
-    #[serde(rename = "baseCoin")]
     pub base_coin: String,
-    #[serde(rename = "quoteCoin")]
     pub quote_coin: String,
-    #[serde(rename = "launchTime", with = "string_to_u64")]
+    #[serde(with = "string_to_u64")]
     pub launch_time: u64,
-    #[serde(rename = "deliveryTime", skip_serializing_if = "String::is_empty")]
+    #[serde(skip_serializing_if = "String::is_empty")]
     pub delivery_time: String,
-    #[serde(rename = "deliveryFeeRate")]
     pub delivery_fee_rate: String,
-    #[serde(rename = "priceScale")]
     pub price_scale: String,
-    #[serde(rename = "leverageFilter")]
     pub leverage_filter: LeverageFilter,
-    #[serde(rename = "priceFilter")]
     pub price_filter: PriceFilter,
-    #[serde(rename = "lotSizeFilter")]
     pub lot_size_filter: LotSizeFilter,
-    #[serde(rename = "unifiedMarginTrade")]
     pub unified_margin_trade: bool,
-    #[serde(rename = "fundingInterval")]
     pub funding_interval: u64,
-    #[serde(rename = "settleCoin")]
     pub settle_coin: String,
-    #[serde(rename = "copyTrading")]
     pub copy_trading: String,
-    #[serde(rename = "upperFundingRate")]
     pub upper_funding_rate: String,
-    #[serde(rename = "lowerFundingRate")]
     pub lower_funding_rate: String,
     // #[serde(rename = "isPreListing" )]
     // pub is_pre_listing: bool,
@@ -278,12 +269,9 @@ pub struct FuturesInstrument {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct SpotInstrumentsInfoResponse {
-    #[serde(rename = "retCode")]
     pub ret_code: i16,
-    #[serde(rename = "retMsg")]
     pub ret_msg: String,
     pub result: SpotInstrumentsInfo,
-    #[serde(rename = "retExtInfo")]
     pub ret_ext_info: Empty,
     pub time: u64,
 }
@@ -293,26 +281,23 @@ pub struct SpotInstrumentsInfoResponse {
 pub struct SpotInstrumentsInfo {
     pub category: String,
     pub list: Vec<SpotInstrument>,
-    #[serde(rename = "nextPageCursor", skip_serializing_if = "String::is_empty")]
+    #[serde(skip_serializing_if = "String::is_empty")]
     pub next_page_cursor: String,
 }
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct SpotInstrument {
     pub symbol: String,
-    #[serde(rename = "baseCoin")]
     pub base_coin: String,
-    #[serde(rename = "quoteCoin")]
     pub quote_coin: String,
-    pub innovation: String,
+    #[serde(with = "string_to_u64")]
+    pub innovation: u64,
     pub status: String,
-    #[serde(rename = "marginTrading")]
     pub margin_trading: String,
-    #[serde(rename = "lotSizeFilter")]
+    #[serde(with = "string_to_u64")]
+    pub st_tag: u64,
     pub lot_size_filter: LotSizeFilter,
-    #[serde(rename = "priceFilter")]
     pub price_filter: PriceFilter,
-    #[serde(rename = "riskParameters")]
     pub risk_parameters: RiskParameters,
 }
 
@@ -321,23 +306,16 @@ pub struct SpotInstrument {
 pub struct OptionsInstrument {
     pub symbol: String,
     pub status: String,
-    #[serde(rename = "baseCoin")]
     pub base_coin: String,
-    #[serde(rename = "quoteCoin")]
     pub quote_coin: String,
-    #[serde(rename = "settleCoin")]
     pub settle_coin: String,
-    #[serde(rename = "optionType")]
     pub option_type: String,
-    #[serde(rename = "launchTime", with = "string_to_u64")]
+    #[serde(with = "string_to_u64")]
     pub launch_time: u64,
-    #[serde(rename = "deliveryTime", with = "string_to_u64")]
+    #[serde(with = "string_to_u64")]
     pub delivery_time: u64,
-    #[serde(rename = "deliveryFeeRate")]
     pub delivery_fee_rate: String,
-    #[serde(rename = "priceFilter")]
     pub price_filter: PriceFilter,
-    #[serde(rename = "lotSizeFilter")]
     pub lot_size_filter: LotSizeFilter,
 }
 

--- a/tests/market_test.rs
+++ b/tests/market_test.rs
@@ -1,7 +1,7 @@
 use bybit::api::*;
 use bybit::config::*;
 use bybit::market::*;
-use bybit::model::{Category, InstrumentRequest, KlineRequest, OrderbookRequest};
+use bybit::model::{Category, InstrumentRequest, KlineRequest, OrderbookRequest, InstrumentInfo};
 use tokio;
 use tokio::time::{Duration, Instant};
 
@@ -83,16 +83,28 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_instrument() {
+    async fn test_futures_instrument() {
         let market: MarketData = Bybit::new(None, None);
-        let request = InstrumentRequest::new(Category::Linear, Some("APTUSDT"), None, None, None);
-        let instrument = market.get_futures_instrument_info(request.clone()).await;
+        let request = InstrumentRequest::new(Category::Linear, Some("ETHUSDT"), None, None, None);
+        let instrument = market.get_instrument_info(request).await;
         if let Ok(data) = instrument {
-            println!("{:#?}", data.result.list[0]);
+            match data.result {
+             InstrumentInfo::Futures(futures) => println!("{:#?}", futures.list[0]),
+             _ => println!("not futures"),
+            }
         }
-        let spot_instrument = market.get_spot_instrument_info(request).await;
-        if let Ok(data) = spot_instrument {
-            println!("{:#?}", data.result.list[0]);
+    }
+
+    #[tokio::test]
+    async fn test_spot_instrument() {
+        let market: MarketData = Bybit::new(None, None);
+        let request = InstrumentRequest::new(Category::Spot, Some("ETHUSDT"), None, None, None);
+        let instrument = market.get_instrument_info(request).await;
+        if let Ok(data) = instrument {
+            match data.result {
+            InstrumentInfo::Spot(spot) => println!("{:#?}", spot.list[0]),
+            _ => println!("not spot"),
+            }
         }
     }
 

--- a/tests/market_test.rs
+++ b/tests/market_test.rs
@@ -19,14 +19,65 @@ mod tests {
         let market: MarketData = Bybit::new(None, None);
         let request = KlineRequest::new(
             Some(Category::Linear),
-            "MATICUSDT",
+            "ETHUSDT",
             "60",
             Some("010124"),
             Some("050224"),
             None,
         );
-        let premium = market.get_klines(request).await;
-        if let Ok(data) = premium {
+        let klines = market.get_klines(request).await;
+        if let Ok(data) = klines {
+            println!("{:#?}", data.result.list);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_mark_klines() {
+        let market: MarketData = Bybit::new(None, None);
+        let request = KlineRequest::new(
+            Some(Category::Linear),
+            "ETHUSDT",
+            "60",
+            Some("010124"),
+            Some("050224"),
+            None,
+        );
+        let mark_klines = market.get_mark_price_klines(request).await;
+        if let Ok(data) = mark_klines {
+            println!("{:#?}", data.result.list);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_index_klines() {
+        let market: MarketData = Bybit::new(None, None);
+        let request = KlineRequest::new(
+            Some(Category::Linear),
+            "ETHUSDT",
+            "60",
+            Some("010124"),
+            Some("050224"),
+            None,
+        );
+        let index_klines = market.get_index_price_klines(request).await;
+        if let Ok(data) = index_klines {
+            println!("{:#?}", data.result.list);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_premium_klines() {
+        let market: MarketData = Bybit::new(None, None);
+        let request = KlineRequest::new(
+            Some(Category::Linear),
+            "ETHUSDT",
+            "60",
+            Some("010124"),
+            Some("050224"),
+            None,
+        );
+        let premium_klines = market.get_premium_index_price_klines(request).await;
+        if let Ok(data) = premium_klines {
             println!("{:#?}", data.result.list);
         }
     }
@@ -118,8 +169,7 @@ mod tests {
     #[tokio::test]
     async fn test_open_interest() {
         let market: MarketData = Bybit::new(None, None);
-        let request =
-            OpenInterestRequest::new(Category::Linear, "ETHUSDT", "1h", None, None, None);
+        let request = OpenInterestRequest::new(Category::Linear, "ETHUSDT", "1h", None, None, None);
         let open_interest = market.get_open_interest(request).await;
         if let Ok(data) = open_interest {
             println!("{:#?}", data.result.list.last().unwrap());

--- a/tests/market_test.rs
+++ b/tests/market_test.rs
@@ -1,7 +1,7 @@
 use bybit::api::*;
 use bybit::config::*;
 use bybit::market::*;
-use bybit::model::{Category, InstrumentRequest, KlineRequest, OrderbookRequest, InstrumentInfo};
+use bybit::model::{Category, InstrumentInfo, InstrumentRequest, KlineRequest, OrderbookRequest};
 use tokio;
 use tokio::time::{Duration, Instant};
 
@@ -11,7 +11,7 @@ mod tests {
     use super::*;
     use bybit::model::{
         FundingHistoryRequest, HistoricalVolatilityRequest, OpenInterestRequest,
-        RecentTradesRequest, RiskLimitRequest,
+        RecentTradesRequest, RiskLimitRequest, TickerData,
     };
 
     #[tokio::test]
@@ -89,8 +89,8 @@ mod tests {
         let instrument = market.get_instrument_info(request).await;
         if let Ok(data) = instrument {
             match data.result {
-             InstrumentInfo::Futures(futures) => println!("{:#?}", futures.list[0]),
-             _ => println!("not futures"),
+                InstrumentInfo::Futures(futures) => println!("{:#?}", futures.list[0]),
+                _ => println!("not futures"),
             }
         }
     }
@@ -102,8 +102,8 @@ mod tests {
         let instrument = market.get_instrument_info(request).await;
         if let Ok(data) = instrument {
             match data.result {
-            InstrumentInfo::Spot(spot) => println!("{:#?}", spot.list[0]),
-            _ => println!("not spot"),
+                InstrumentInfo::Spot(spot) => println!("{:#?}", spot.list[0]),
+                _ => println!("not spot"),
             }
         }
     }
@@ -144,16 +144,29 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_ticker() {
+    async fn test_futures_ticker() {
         let market: MarketData = Bybit::new(None, None);
-        let symbol = "APTUSDT";
-        let ticker = market.get_futures_tickers(Some(symbol)).await;
-        if let Ok(data) = ticker {
-            println!("{:#?}", data.result.list);
+        let symbol = "ETHUSDT";
+        let futures_ticker = market.get_tickers(Some(symbol), Category::Linear).await;
+        if let Ok(data) = futures_ticker {
+            match &data.result.list[0] {
+                TickerData::Futures(futures) => println!("{:#?}", futures),
+                _ => println!("not futures"),
+            }
         }
-        let spot_ticker = market.get_spot_tickers(Some(symbol)).await;
+    }
+
+
+    #[tokio::test]
+    async fn test_spot_ticker() {
+        let market: MarketData = Bybit::new(None, None);
+        let symbol = "ETHUSDT";
+        let spot_ticker = market.get_tickers(Some(symbol), Category::Spot).await;
         if let Ok(data) = spot_ticker {
-            println!("{:#?}", data.result.list);
+            match &data.result.list[0].clone() {
+                TickerData::Spot(spot) => println!("{:#?}", spot),
+                _ => println!("not spot"),
+            }
         }
     }
 


### PR DESCRIPTION
Improve clarity in response structs by removing unnecessary serde renames and consolidating instrument info handling. Update Kline request tests to focus on 'ETHUSDT' and add additional test cases for futures and spot instruments.