### PR TITLE
Update PositionInfo: change `stop_loss` and `take_profit` to be optional None if string is empty.

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -918,7 +918,8 @@ pub struct LongShortRatio {
 /// --------------------------------------------------
 ///  REQUEST & RESPONSE STRUCTS FOR TRADE
 /// --------------------------------------------------
-#[derive(Clone, Copy, Default, Serialize)]
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum Category {
     Spot,
     #[default]
@@ -926,6 +927,7 @@ pub enum Category {
     Inverse,
     Option,
 }
+
 impl Category {
     pub fn as_str(&self) -> &str {
         match self {
@@ -2195,57 +2197,89 @@ mod string_to_float_optional {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct PositionInfo {
+    
     pub position_idx: i32,
+    
     pub risk_id: i32,
+    
     #[serde(with = "string_to_float")]
     pub risk_limit_value: f64,
+    
     pub symbol: String,
-    pub side: String,
+    
+    pub side: Side,
+    
     #[serde(with = "string_to_float")]
     pub size: f64,
+    
     #[serde(with = "string_to_float_optional")]
     pub avg_price: Option<f64>,
+    
     #[serde(with = "string_to_float_optional")]
     pub position_value: Option<f64>,
+    
     pub trade_mode: i32,
+    
     pub position_status: String,
+    
     pub auto_add_margin: i32,
+    
     pub adl_rank_indicator: i32,
+    
     #[serde(with = "string_to_float_optional")]
     pub leverage: Option<f64>,
+    
     #[serde(with = "string_to_float")]
     pub position_balance: f64,
+    
     #[serde(with = "string_to_float")]
     pub mark_price: f64,
+    
     #[serde(with = "string_to_float_optional")]
     pub liq_price: Option<f64>,
+    
     #[serde(with = "string_to_float")]
     pub bust_price: f64,
+    
     #[serde(rename = "positionMM", with = "string_to_float_optional")]
     pub position_mm: Option<f64>,
+    
     #[serde(rename = "positionIM", with = "string_to_float_optional")]
     pub position_im: Option<f64>,
+    
     pub tpsl_mode: String,
+    
     #[serde(with = "string_to_float")]
     pub take_profit: f64,
+    
     #[serde(with = "string_to_float")]
     pub stop_loss: f64,
+    
     pub trailing_stop: String,
+    
     #[serde(with = "string_to_float_optional")]
     pub unrealised_pnl: Option<f64>,
+    
     #[serde(with = "string_to_float_optional")]
     pub cum_realised_pnl: Option<f64>,
+    
     pub seq: u64,
+    
     pub is_reduce_only: bool,
+    
     #[serde(with = "string_to_u64_optional")]
     pub mmr_sys_updated_time: Option<u64>,
+    
     #[serde(with = "string_to_u64_optional")]
     pub leverage_sys_updated_time: Option<u64>,
+    
     #[serde(with = "string_to_u64")]
     pub created_time: u64,
+    
     #[serde(with = "string_to_u64")]
     pub updated_time: u64,
 }
+
 #[cfg(test)]
 mod test_decode_position_info {
     use super::*;
@@ -2607,38 +2641,62 @@ pub struct AddReduceMarginResponse {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct AddReduceMarginResult {
-    pub category: String,
+    
+    pub category: Category,
+    
     pub symbol: String,
+    
     pub position_idx: i32,
+    
     pub risk_id: i32,
+    
     #[serde(with = "string_to_float")]
     pub risk_limit_value: f64,
+    
     #[serde(with = "string_to_float")]
     pub size: f64,
+    
     #[serde(with = "string_to_float")]
     pub position_value: f64,
+    
     #[serde(with = "string_to_float")]
     pub avg_price: f64,
+    
     #[serde(with = "string_to_float")]
     pub liq_price: f64,
+    
     #[serde(with = "string_to_float")]
     pub bust_price: f64,
+    
     #[serde(with = "string_to_float")]
     pub mark_price: f64,
+    
     pub leverage: String,
     pub auto_add_margin: i32,
     pub position_status: String,
+    
     #[serde(rename = "positionIM")]
     pub position_im: String,
+    
     #[serde(rename = "positionMM")]
     pub position_mm: String,
+    
     pub unrealised_pnl: String,
     pub cum_realised_pnl: String,
-    pub stop_loss: String,
-    pub take_profit: String,
+
+    #[serde(with = "string_to_float_optional")]
+    pub stop_loss: Option<f64>,
+
+    #[serde(with = "string_to_float_optional")]
+    pub take_profit: Option<f64>,
+
     pub trailing_stop: String,
-    pub created_time: String,
-    pub updated_time: String,
+
+    #[serde(with = "string_to_u64")]
+    pub created_time: u64,
+
+    #[serde(with = "string_to_u64")]
+    pub updated_time: u64,
 }
 
 #[derive(Clone, Default)]


### PR DESCRIPTION
@unkuseni Fix PositionInfo and some other models, specifically where we try to deserialize multiple fields as `f64` but they can be: `""`. 