### PR TITLE
Refactor WalletData struct to use Option<f64> for rates and balances

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -3952,11 +3952,11 @@ unsafe impl Sync for WalletEvent {}
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct WalletData {
-    #[serde(rename = "accountIMRate")]
-    pub account_im_rate: String,
+    #[serde(rename = "accountIMRate", with = "string_to_float_optional")]
+    pub account_im_rate: Option<f64>,
 
-    #[serde(rename = "accountMMRate")]
-    pub account_mm_rate: String,
+    #[serde(rename = "accountMMRate", with = "string_to_float_optional")]
+    pub account_mm_rate: Option<f64>,
 
     #[serde(with = "string_to_float")]
     pub total_equity: f64,
@@ -3964,25 +3964,25 @@ pub struct WalletData {
     #[serde(with = "string_to_float")]
     pub total_wallet_balance: f64,
 
-    #[serde(with = "string_to_float")]
-    pub total_margin_balance: f64,
+    #[serde(with = "string_to_float_optional")]
+    pub total_margin_balance: Option<f64>,
 
-    #[serde(with = "string_to_float")]
-    pub total_available_balance: f64,
+    #[serde(with = "string_to_float_optional")]
+    pub total_available_balance: Option<f64>,
 
     #[serde(rename = "totalPerpUPL", with = "string_to_float")]
     pub total_perp_upl: f64,
 
-    #[serde(with = "string_to_float")]
-    pub total_initial_margin: f64,
+    #[serde(with = "string_to_float_optional")]
+    pub total_initial_margin: Option<f64>,
 
-    #[serde(with = "string_to_float")]
-    pub total_maintenance_margin: f64,
+    #[serde(with = "string_to_float_optional")]
+    pub total_maintenance_margin: Option<f64>,
 
     pub coin: Vec<CoinData>,
 
-    #[serde(rename = "accountLTV")]
-    pub account_ltv: String,
+    #[serde(rename = "accountLTV", with = "string_to_float_optional")]
+    pub account_ltv: Option<f64>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub account_type: Option<String>,
@@ -4020,11 +4020,11 @@ pub struct CoinData {
     #[serde(rename = "totalOrderIM", with = "string_to_float")]
     pub total_order_im: f64,
 
-    #[serde(rename = "totalPositionIM")]
-    pub total_position_im: String,
+    #[serde(rename = "totalPositionIM", with = "string_to_float")]
+    pub total_position_im: f64,
 
-    #[serde(rename = "totalPositionMM")]
-    pub total_position_mm: String,
+    #[serde(rename = "totalPositionMM", with = "string_to_float")]
+    pub total_position_mm: f64,
 
     #[serde(with = "string_to_float")]
     pub unrealised_pnl: f64,
@@ -4032,15 +4032,18 @@ pub struct CoinData {
     #[serde(with = "string_to_float")]
     pub cum_realised_pnl: f64,
 
-    pub bonus: String,
+    #[serde(with = "string_to_float")]
+    pub bonus: f64,
 
     pub collateral_switch: bool,
 
     pub margin_collateral: bool,
 
-    pub locked: String,
+    #[serde(with = "string_to_float")]
+    pub locked: f64,
 
-    pub spot_hedging_qty: String,
+    #[serde(with = "string_to_float")]
+    pub spot_hedging_qty: f64,
 }
 
 unsafe impl Send for CoinData {}

--- a/src/model.rs
+++ b/src/model.rs
@@ -2240,8 +2240,8 @@ pub struct PositionInfo {
     #[serde(with = "string_to_float")]
     pub size: f64,
 
-    #[serde(with = "string_to_float_optional")]
-    pub avg_price: Option<f64>,
+    #[serde(with = "string_to_float")]
+    pub avg_price: f64,
 
     #[serde(with = "string_to_float_optional")]
     pub position_value: Option<f64>,
@@ -2254,8 +2254,8 @@ pub struct PositionInfo {
 
     pub adl_rank_indicator: i32,
 
-    #[serde(with = "string_to_float_optional")]
-    pub leverage: Option<f64>,
+    #[serde(with = "string_to_float")]
+    pub leverage: f64,
 
     #[serde(with = "string_to_float")]
     pub position_balance: f64,
@@ -2269,11 +2269,11 @@ pub struct PositionInfo {
     #[serde(with = "string_to_float_optional")]
     pub bust_price: Option<f64>,
 
-    #[serde(rename = "positionMM", with = "string_to_float_optional")]
-    pub position_mm: Option<f64>,
+    #[serde(rename = "positionMM", with = "string_to_float")]
+    pub position_mm: f64,
 
-    #[serde(rename = "positionIM", with = "string_to_float_optional")]
-    pub position_im: Option<f64>,
+    #[serde(rename = "positionIM", with = "string_to_float")]
+    pub position_im: f64,
 
     pub tpsl_mode: String,
 
@@ -2283,15 +2283,16 @@ pub struct PositionInfo {
     #[serde(with = "string_to_float_optional")]
     pub stop_loss: Option<f64>,
 
-    pub trailing_stop: String,
+    #[serde(with = "string_to_float")]
+    pub trailing_stop: f64,
 
     #[serde(with = "string_to_float_optional")]
     pub unrealised_pnl: Option<f64>,
 
-    #[serde(with = "string_to_float_optional")]
-    pub cum_realised_pnl: Option<f64>,
+    #[serde(with = "string_to_float")]
+    pub cum_realised_pnl: f64,
 
-    pub seq: u64,
+    pub seq: i64,
 
     pub is_reduce_only: bool,
 

--- a/tests/account_test.rs
+++ b/tests/account_test.rs
@@ -3,13 +3,13 @@ use bybit::model::*;
 
 #[cfg(test)]
 mod tests {
-    use bybit::account::AccountManager;
-
     use super::*;
+    use bybit::account::AccountManager;
+    use tokio::test;
     static API_KEY: &str = ""; //Mockup string
     static SECRET: &str = ""; // Mockup string
 
-    #[tokio::test]
+    #[test]
     async fn test_wallet() {
         let account: AccountManager = Bybit::new(Some(API_KEY.into()), Some(SECRET.into()));
         let wallet = account.get_wallet_balance("UNIFIED", None).await;
@@ -17,7 +17,7 @@ mod tests {
         println!("{:#?}", wallet);
     }
 
-    #[tokio::test]
+    #[test]
     async fn test_fee_rate() {
         let account: AccountManager = Bybit::new(Some(API_KEY.into()), Some(SECRET.into()));
         let wallet = account
@@ -27,7 +27,7 @@ mod tests {
         println!("{:?}", wallet);
     }
 
-    #[tokio::test]
+    #[test]
     async fn test_borrow_history() {
         let account: AccountManager = Bybit::new(Some(API_KEY.into()), Some(SECRET.into()));
         let wallet = account.get_fee_rate(Category::Spot, None).await;

--- a/tests/account_test.rs
+++ b/tests/account_test.rs
@@ -14,7 +14,7 @@ mod tests {
         let account: AccountManager = Bybit::new(Some(API_KEY.into()), Some(SECRET.into()));
         let wallet = account.get_wallet_balance("UNIFIED", None).await;
 
-        println!("{:?}", wallet);
+        println!("{:#?}", wallet);
     }
 
     #[tokio::test]

--- a/tests/market_test.rs
+++ b/tests/market_test.rs
@@ -6,14 +6,14 @@ use tokio::time::{Duration, Instant};
 
 #[cfg(test)]
 mod tests {
-
     use super::*;
     use bybit::model::{
         FundingHistoryRequest, HistoricalVolatilityRequest, OpenInterestRequest,
         RecentTradesRequest, RiskLimitRequest, TickerData,
     };
+    use tokio::test;
 
-    #[tokio::test]
+    #[test]
     async fn test_kline() {
         let market: MarketData = Bybit::new(None, None);
         let request = KlineRequest::new(
@@ -30,7 +30,7 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[test]
     async fn test_mark_klines() {
         let market: MarketData = Bybit::new(None, None);
         let request = KlineRequest::new(
@@ -47,7 +47,7 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[test]
     async fn test_index_klines() {
         let market: MarketData = Bybit::new(None, None);
         let request = KlineRequest::new(
@@ -64,7 +64,7 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[test]
     async fn test_premium_klines() {
         let market: MarketData = Bybit::new(None, None);
         let request = KlineRequest::new(
@@ -81,7 +81,7 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[test]
     async fn test_futures_instrument() {
         let market: MarketData = Bybit::new(None, None);
         let request = InstrumentRequest::new(Category::Linear, Some("ETHUSDT"), None, None, None);
@@ -94,7 +94,7 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[test]
     async fn test_spot_instrument() {
         let market: MarketData = Bybit::new(None, None);
         let request = InstrumentRequest::new(Category::Spot, Some("ETHUSDT"), None, None, None);
@@ -107,7 +107,7 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[test]
     async fn test_market() {
         let market: MarketData = Bybit::new(None, None);
         let five_minutes = Duration::from_secs(5 * 60);
@@ -142,7 +142,7 @@ mod tests {
         (percent / 100.0) * value
     }
 
-    #[tokio::test]
+    #[test]
     async fn test_futures_ticker() {
         let market: MarketData = Bybit::new(None, None);
         let symbol = "ETHUSDT";
@@ -155,7 +155,7 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[test]
     async fn test_spot_ticker() {
         let market: MarketData = Bybit::new(None, None);
         let symbol = "ETHUSDT";
@@ -168,7 +168,7 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[test]
     async fn test_recent_trades() {
         let market: MarketData = Bybit::new(None, None);
         let request = RecentTradesRequest::new(Category::Linear, Some("POLUSDT"), None, None);
@@ -178,7 +178,7 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[test]
     async fn test_funding_rate() {
         let market: MarketData = Bybit::new(None, None);
         let symbol = "BTCUSDT";
@@ -189,7 +189,7 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[test]
     async fn test_open_interest() {
         let market: MarketData = Bybit::new(None, None);
         let request = OpenInterestRequest::new(Category::Linear, "ETHUSDT", "1h", None, None, None);
@@ -199,7 +199,7 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[test]
     async fn test_historical_volatility() {
         let market: MarketData = Bybit::new(None, None);
         let symbol = "ETH";
@@ -211,7 +211,7 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[test]
     async fn test_insurance() {
         let market: MarketData = Bybit::new(None, None);
         let symbol = Some("BTC");
@@ -221,7 +221,7 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[test]
     async fn test_risk_limit() {
         let market: MarketData =
             Bybit::new_with_config(&Config::default().set_recv_window(1000), None, None);
@@ -233,7 +233,7 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[test]
     async fn test_delivery_price() {
         let market: MarketData = Bybit::new(None, None);
         let symbol = "BTCUSDT";


### PR DESCRIPTION
Update the WalletData struct to use `Option<f64>` for various financial rates and balances, allowing for better handling of optional values. Adjust related tests for improved output formatting.